### PR TITLE
fix: correct rank value in updateVisualsByPriority to prevent black s…

### DIFF
--- a/lib/src/components/CircleShape.dart
+++ b/lib/src/components/CircleShape.dart
@@ -75,7 +75,7 @@ class CircleShape extends PositionComponent
   void updateVisualsByPriority() {
     // This is now legacy; OneSecondGame calls updateVisualsByRank instead.
     // Default to rank 0 (intense) if unsure.
-    updateVisualsByRank(0.0);
+    updateVisualsByRank(1.0);
   }
 
   void setBlinkAlpha(double alpha) {

--- a/lib/src/components/HexagonShape.dart
+++ b/lib/src/components/HexagonShape.dart
@@ -99,7 +99,7 @@ class HexagonShape extends PositionComponent
 
   @override
   void updateVisualsByPriority() {
-    updateVisualsByRank(0.0);
+    updateVisualsByRank(1.0);
   }
 
   void setBlinkAlpha(double alpha) {

--- a/lib/src/components/PentagonShape.dart
+++ b/lib/src/components/PentagonShape.dart
@@ -72,7 +72,7 @@ class PentagonShape extends PositionComponent
 
   @override
   void updateVisualsByPriority() {
-    updateVisualsByRank(0.0);
+    updateVisualsByRank(1.0);
   }
 
   void setBlinkAlpha(double alpha) {

--- a/lib/src/components/RectangleShape.dart
+++ b/lib/src/components/RectangleShape.dart
@@ -133,7 +133,7 @@ class RectangleShape extends PositionComponent
 
   @override
   void updateVisualsByPriority() {
-    updateVisualsByRank(0.0);
+    updateVisualsByRank(1.0);
   }
 
   void setBlinkAlpha(double alpha) {

--- a/lib/src/components/TriangleShape.dart
+++ b/lib/src/components/TriangleShape.dart
@@ -58,7 +58,7 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
 
   @override
   void updateVisualsByPriority() {
-    updateVisualsByRank(0.0);
+    updateVisualsByRank(1.0);
   }
 
   void setBlinkAlpha(double alpha){


### PR DESCRIPTION
…hapes

Changed rank argument from 0.0 to 1.0 in all shapes' updateVisualsByPriority(). rank=0.0 was multiplying RGB by zero, turning shapes black when called before _syncRelativeDepthVisuals() could correct it.