### PR TITLE
fix: block triangle removal when any non-triangle shape is inside cir…

### DIFF
--- a/lib/src/routes/OneSecondGame.dart
+++ b/lib/src/routes/OneSecondGame.dart
@@ -2315,6 +2315,7 @@ bool _isStraightLine(List<Vector2> path) {
       bool isDarkTriangle = comp is TriangleShape && comp.isDark;
 
       if (comp is TriangleShape && !isDarkTriangle) {
+        // 일반 삼각형만 제거 대상
         if (comp.isFullyEnclosedByUserPath(judgePath)) {
           enclosedTriangles.add(comp);
         }
@@ -2324,10 +2325,14 @@ bool _isStraightLine(List<Vector2> path) {
           comp is HexagonShape ||
           isDarkTriangle) {
 
+        // 삼각형 외 모든 게임 도형 + dark 삼각형 → 원 안에 있으면 막기
+        // Pentagon/Hexagon처럼 큰 도형은 꼭짓점이 원 밖에 나와 enclosed가 false일 수 있으므로
+        // 중심점이 원 안에 있는지도 추가로 체크
         final enclosed = _isComponentEnclosed(comp, judgePath);
         final touched = _doesPathTouchComponent(comp, judgePath);
+        final centerInside = _isPointInPolygon(comp.absoluteCenter, judgePath);
 
-        if (enclosed || touched) {
+        if (enclosed || touched || centerInside) {
           touchedOtherShapes.add(comp);
         }
       }


### PR DESCRIPTION
Enhancement of Circle Gesture Detection: Added Center-Point Validation

1. Overview

Fixed an issue where triangles were incorrectly removed even when non-target shapes (such as Pentagons or Hexagons) were present inside the drawn circle.
2. Key Changes (Logic Enhancement)

Previously, detection relied solely on _isComponentEnclosed (entire shape inside) and _doesPathTouchComponent (path intersection).
The Issue: Larger shapes like Pentagons or Hexagons often have corners that stick out of the circle even when their body is mostly inside, causing detection to fail.
The Solution: Enhanced the logic by adding a center-point validation using _isPointInPolygon on the shape's absoluteCenter.
3. Expected Results

Shapes are now accurately detected even if their corners are partially outside the circle, as long as the center point is within the drawn path.
This ensures that any non-triangle shape (including dark shapes) correctly blocks triangle removal and triggers the appropriate penalty.
This pull request updates the logic for detecting which game shapes are affected by the user's path in `OneSecondGame.dart`. The main focus is to improve how the game determines whether shapes—especially larger ones like pentagons and hexagons—are considered "touched" by the user's drawn path, ensuring more accurate gameplay.
