### PR TITLE
Feat/debug damage number display

### DIFF
--- a/lib/src/components/GameTimerComponent.dart
+++ b/lib/src/components/GameTimerComponent.dart
@@ -119,16 +119,17 @@ class GameTimerComponent extends PositionComponent {
   
   void flashPenalty({double durationSec = 0.4}) {
     if (!_ready) return;
+
+    // 1) 타이머 텍스트 빨갛게 → durationSec 후 검정 복구
     timerText.textRenderer = TextPaint(
       style: const TextStyle(
         fontFamily: 'Moulpali',
         fontSize: 16,
         height: 21 / 16,
         letterSpacing: -0.32,
-        color: Colors.red, // 빨간색
+        color: Colors.red,
       ),
     );
-    // 일정 시간 뒤 검정으로 복구
     add(
       TimerComponent(
         period: durationSec,
@@ -147,6 +148,31 @@ class GameTimerComponent extends PositionComponent {
         repeat: false,
       ),
     );
+
+    // 2) 타이머 바 빨갛게 → 1초 후 원래 색으로 복구
+    //    이미 10초 이하(영구 빨간 상태)이면 건드리지 않음
+    if (bar != null && currentTime > 10.0 + _epsilon) {
+      bar!.paint = Paint()
+        ..colorFilter = const ColorFilter.mode(Colors.red, BlendMode.srcIn);
+      add(
+        TimerComponent(
+          period: 1.0,
+          onTick: () {
+            if (bar == null) return;
+            // 복구 시점에 여전히 10초 초과이면 초록으로, 이하이면 빨간 유지
+            if (currentTime <= 10.0 + _epsilon) {
+              bar!.paint = Paint()
+                ..colorFilter =
+                    const ColorFilter.mode(Colors.red, BlendMode.srcIn);
+            } else {
+              bar!.paint = Paint(); // 원본 초록 복구
+            }
+          },
+          removeOnFinish: true,
+          repeat: false,
+        ),
+      );
+    }
   }
 
   /// 타이머 바 위 중앙에 데미지 숫자를 잠깐 표시합니다.
@@ -156,8 +182,8 @@ class GameTimerComponent extends PositionComponent {
 
     final damageText = TextComponent(
       text: '-${damage.toStringAsFixed(0)}',
-      anchor: Anchor.bottomRight,
-      position: Vector2(size.x, -4),
+      anchor: Anchor.topRight,
+      position: Vector2(size.x - 5, -22),
       textRenderer: TextPaint(
         style: const TextStyle(
           fontFamily: 'Moulpali',

--- a/lib/src/components/GameTimerComponent.dart
+++ b/lib/src/components/GameTimerComponent.dart
@@ -148,4 +148,43 @@ class GameTimerComponent extends PositionComponent {
       ),
     );
   }
+
+  /// 타이머 바 위 중앙에 데미지 숫자를 잠깐 표시합니다.
+  /// 예: -3s
+  void showDamageNumber(double damage) {
+    if (!_ready) return;
+
+    final damageText = TextComponent(
+      text: '-${damage.toStringAsFixed(0)}s',
+      anchor: Anchor.bottomCenter,
+      position: Vector2(size.x / 2, -4),
+      textRenderer: TextPaint(
+        style: const TextStyle(
+          fontFamily: 'Moulpali',
+          fontSize: 18,
+          color: Colors.red,
+          fontWeight: FontWeight.bold,
+          shadows: [
+            Shadow(
+              color: Colors.black54,
+              offset: Offset(1, 1),
+              blurRadius: 2,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    add(damageText);
+
+    // 1초 후 자동 제거
+    add(
+      TimerComponent(
+        period: 1.0,
+        onTick: () => damageText.removeFromParent(),
+        removeOnFinish: true,
+        repeat: false,
+      ),
+    );
+  }
 }

--- a/lib/src/components/GameTimerComponent.dart
+++ b/lib/src/components/GameTimerComponent.dart
@@ -155,9 +155,9 @@ class GameTimerComponent extends PositionComponent {
     if (!_ready) return;
 
     final damageText = TextComponent(
-      text: '-${damage.toStringAsFixed(0)}s',
-      anchor: Anchor.bottomCenter,
-      position: Vector2(size.x / 2, -4),
+      text: '-${damage.toStringAsFixed(0)}',
+      anchor: Anchor.bottomRight,
+      position: Vector2(size.x, -4),
       textRenderer: TextPaint(
         style: const TextStyle(
           fontFamily: 'Moulpali',

--- a/lib/src/routes/OneSecondGame.dart
+++ b/lib/src/routes/OneSecondGame.dart
@@ -384,6 +384,7 @@ class OneSecondGame extends FlameGame
 
     updateTimerUI();
     timerBar.flashPenalty();
+    timerBar.showDamageNumber(seconds); // 데미지 숫자 타이머 바 위에 표시
     
     if (currentMissionTime <= 0 && !_timerEndedNotified) {
       _timerEndedNotified = true;


### PR DESCRIPTION
## Summary
Enhances visual feedback when a time penalty (`applyTimePenalty`) is triggered,
making it clearer to the player how much time was lost.
## Changes
### `GameTimerComponent.dart`
- Added `showDamageNumber(double damage)` method
  - Renders a `-N` text above the top-right of the timer bar for 1 second, then auto-removes via `TimerComponent`
- Extended `flashPenalty()` to also flash the timer bar
  - Previously: only the timer text turned red for 0.4s
  - Now: the timer bar SVG also applies a red `colorFilter` for 1 second, then restores its original color
  - If remaining time is ≤ 10s (already permanently red), the bar flash is skipped to avoid conflict
### `OneSecondGame.dart`
- Added `timerBar.showDamageNumber(seconds)` call inside `applyTimePenalty()`
## Behavior Flow
1. Penalty triggered
2. Timer text → red for 0.4s, then restores to black
3. Timer bar → red for 1s, then restores to green (only if remaining time > 10s)
4. `-N` damage number appears above the top-right of the timer bar for 1s