### PR TITLE
fix: resume pentagon effects on tap up

### DIFF
--- a/lib/src/components/PentagonShape.dart
+++ b/lib/src/components/PentagonShape.dart
@@ -551,6 +551,7 @@ class PentagonShape extends PositionComponent
 
     _isLongPressing = false;
     _frozenPosition = null;
+    children.whereType<Effect>().forEach((effect) => effect.resume());
     _myBlinking()?.isPaused = false;
   }
 


### PR DESCRIPTION
Effects paused in onTapDown were not being resumed on onTapUp, causing the pentagon to stay frozen after releasing the press.