### PR TITLE
feat: Add HP display badge on all shapes (top-right corner)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,18 @@ assets/.env
 
 # Personal notes and README backup
 README_paul.md
+
+# Local platform directories (each dev manages their own)
+android/
+ios/
+linux/
+macos/
+web/
+windows/
+
+# Flutter local metadata
+.metadata
+analysis_options.yaml
+
+# Test directory (local only)
+test/

--- a/lib/src/components/CircleShape.dart
+++ b/lib/src/components/CircleShape.dart
@@ -165,7 +165,7 @@ class CircleShape extends PositionComponent
       _png.opacity = 1;
     }
 
-    if (!isDark && count > 0) {
+    if (!isDark && count > 1) {
       _hpTextComponent = TextComponent(
         text: count.toString(),
         anchor: Anchor.topRight,
@@ -312,7 +312,7 @@ class CircleShape extends PositionComponent
   void applyValidInteraction() {
     count--;
 
-    if (count >= 1) {
+    if (count > 1) {
       _hpTextComponent?.text = count.toString();
     } else {
       _hpTextComponent?.removeFromParent();

--- a/lib/src/components/CircleShape.dart
+++ b/lib/src/components/CircleShape.dart
@@ -31,6 +31,7 @@ class CircleShape extends PositionComponent
   final int? order;
 
   late PositionComponent _orderBadge;
+  TextComponent? _hpTextComponent;
 
   double _attackElapsed = 0.0;
   bool _attackDone = false;
@@ -90,6 +91,10 @@ class CircleShape extends PositionComponent
     // if (_png.isMounted) {
       _png.opacity = _blinkAlpha;
     // }
+
+    _hpTextComponent?.textRenderer = TextPaint(
+      style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Colors.black.withValues(alpha: _blinkAlpha)),
+    );
   }
 
   CircleShape(
@@ -158,6 +163,19 @@ class CircleShape extends PositionComponent
     if ((attackTime ?? 0) > 0) {
       _svg.opacity = 0;
       _png.opacity = 1;
+    }
+
+    if (!isDark && count > 0) {
+      _hpTextComponent = TextComponent(
+        text: count.toString(),
+        anchor: Anchor.topRight,
+        position: Vector2(size.x - 4, 4),
+        priority: 999,
+        textRenderer: TextPaint(
+          style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Colors.black),
+        ),
+      );
+      add(_hpTextComponent!);
     }
   }
 
@@ -252,27 +270,6 @@ class CircleShape extends PositionComponent
       );
     }
 
-    if (!isDark && count > 0) {
-      final tp = TextPainter(
-        text: TextSpan(
-          text: count.toString(),
-          style: TextStyle(
-            color:
-                (_attackTimeCritical ? dangerColor : const Color(0xFFFF9D33)).withValues(alpha:_blinkAlpha),
-            fontSize: 20,
-          ),
-        ),
-        textDirection: TextDirection.ltr,
-      )..layout();
-
-      tp.paint(
-        canvas,
-        Offset(
-          (size.x - tp.width) / 2,
-          (size.y - tp.height) / 2,
-        ),
-      );
-    }
   }
 
   Path _buildCirclePath() {
@@ -314,6 +311,13 @@ class CircleShape extends PositionComponent
 
   void applyValidInteraction() {
     count--;
+
+    if (count >= 1) {
+      _hpTextComponent?.text = count.toString();
+    } else {
+      _hpTextComponent?.removeFromParent();
+      _hpTextComponent = null;
+    }
 
     if (count <= 0) {
       wasRemovedByUser = true;

--- a/lib/src/components/HexagonShape.dart
+++ b/lib/src/components/HexagonShape.dart
@@ -173,7 +173,7 @@ class HexagonShape extends PositionComponent
 
     updateVisualsByPriority();
 
-    if (!isDark && energy > 0) {
+    if (!isDark && energy > 1) {
       _hpTextComponent = TextComponent(
         text: energy.toString(),
         anchor: Anchor.topRight,

--- a/lib/src/components/HexagonShape.dart
+++ b/lib/src/components/HexagonShape.dart
@@ -27,6 +27,7 @@ class HexagonShape extends PositionComponent
   late final SpriteComponent _png;
 
   int energy = 0;
+  TextComponent? _hpTextComponent;
 
   final bool isDark;
   final VoidCallback? onForbiddenTouch;
@@ -105,6 +106,10 @@ class HexagonShape extends PositionComponent
   void setBlinkAlpha(double alpha) {
     _blinkAlpha = alpha.clamp(0.0, 1.0);
     svg.opacity = _blinkAlpha * _opacity;
+
+    _hpTextComponent?.textRenderer = TextPaint(
+      style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Colors.black.withValues(alpha: _blinkAlpha)),
+    );
   }
 
   HexagonShape(
@@ -167,6 +172,19 @@ class HexagonShape extends PositionComponent
         _outlinePath.computeMetrics().fold(0.0, (s, m) => s + m.length);
 
     updateVisualsByPriority();
+
+    if (!isDark && energy > 0) {
+      _hpTextComponent = TextComponent(
+        text: energy.toString(),
+        anchor: Anchor.topRight,
+        position: Vector2(size.x - 4, 4),
+        priority: 999,
+        textRenderer: TextPaint(
+          style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Colors.black),
+        ),
+      );
+      add(_hpTextComponent!);
+    }
   }
 
   Path _buildHexagonPath(Size s) {

--- a/lib/src/components/PentagonShape.dart
+++ b/lib/src/components/PentagonShape.dart
@@ -216,7 +216,7 @@ class PentagonShape extends PositionComponent
 
     updateVisualsByPriority();
 
-    if (!isDark && energy > 0) {
+    if (!isDark && energy > 1) {
       _hpTextComponent = TextComponent(
         text: energy.toString(),
         anchor: Anchor.topRight,
@@ -274,7 +274,12 @@ class PentagonShape extends PositionComponent
           return;
         }
 
-        _hpTextComponent?.text = energy.toString();
+        if (energy > 1) {
+          _hpTextComponent?.text = energy.toString();
+        } else {
+          _hpTextComponent?.removeFromParent();
+          _hpTextComponent = null;
+        }
       }
     } else {
 

--- a/lib/src/components/PentagonShape.dart
+++ b/lib/src/components/PentagonShape.dart
@@ -18,6 +18,7 @@ class PentagonShape extends PositionComponent
     with HasPaint, TapCallbacks, UserRemovable, HasGameReference<FlameGame>, DepthAware {
 
   int energy;
+  TextComponent? _hpTextComponent;
   bool _isLongPressing = false;
 
   late final SvgComponent svg;
@@ -85,6 +86,10 @@ class PentagonShape extends PositionComponent
       svg.opacity = _blinkAlpha;
       _png.opacity = 0;
     }
+
+    _hpTextComponent?.textRenderer = TextPaint(
+      style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Colors.black.withValues(alpha: _blinkAlpha)),
+    );
   }
 
   // ===============================
@@ -210,6 +215,19 @@ class PentagonShape extends PositionComponent
         _pentagonPath.computeMetrics().fold(0.0, (s, m) => s + m.length);
 
     updateVisualsByPriority();
+
+    if (!isDark && energy > 0) {
+      _hpTextComponent = TextComponent(
+        text: energy.toString(),
+        anchor: Anchor.topRight,
+        position: Vector2(size.x - 4, 4),
+        priority: 999,
+        textRenderer: TextPaint(
+          style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Colors.black),
+        ),
+      );
+      add(_hpTextComponent!);
+    }
   }
 
   // ===============================
@@ -251,13 +269,12 @@ class PentagonShape extends PositionComponent
         energy--;
 
         if (energy <= 0) {
-
           wasRemovedByUser = true;
-
           removeFromParent();
-
           return;
         }
+
+        _hpTextComponent?.text = energy.toString();
       }
     } else {
 
@@ -366,16 +383,6 @@ class PentagonShape extends PositionComponent
       );
     }
 
-    if (!isDark && energy > 0) {
-
-      _drawText(
-        canvas,
-        energy.toString(),
-        _visualPentagonCenter,
-        20,
-        const Color(0xFFC100BA).withOpacity(_blinkAlpha),
-      );
-    }
   }
 
   // ===============================
@@ -544,6 +551,8 @@ class PentagonShape extends PositionComponent
       removeFromParent();
       return;
     }
+
+    _hpTextComponent?.text = energy.toString();
   }
 
   @override

--- a/lib/src/components/RectangleShape.dart
+++ b/lib/src/components/RectangleShape.dart
@@ -289,7 +289,7 @@ class RectangleShape extends PositionComponent
       _addOrderBadge(order!);
     }
 
-    if (!isDark && count >= 1) {
+    if (!isDark && count > 1) {
       _hpTextComponent = TextComponent(
         text: count.toString(),
         anchor: Anchor.topRight,
@@ -804,7 +804,7 @@ class RectangleShape extends PositionComponent
     print("=== VALID MOVE ==============");
     count--;
 
-    if (count >= 1) {
+    if (count > 1) {
       _hpTextComponent?.text = count.toString();
     } else {
       _hpTextComponent?.removeFromParent();

--- a/lib/src/components/RectangleShape.dart
+++ b/lib/src/components/RectangleShape.dart
@@ -33,6 +33,7 @@ class RectangleShape extends PositionComponent
   double _blinkAlpha = 1.0;
   CircleComponent? _orderBadgeBg;
   TextComponent? _orderBadgeText;
+  TextComponent? _hpTextComponent;
 
   bool isSliced = false;
   Vector2? sliceStart;
@@ -162,6 +163,16 @@ class RectangleShape extends PositionComponent
         ),
       );
     }
+
+    if (_hpTextComponent != null) {
+      _hpTextComponent!.textRenderer = TextPaint(
+        style: TextStyle(
+          fontSize: 20,
+          fontWeight: FontWeight.bold,
+          color: Colors.black.withValues(alpha: _blinkAlpha),
+        ),
+      );
+    }
   }
 
   @override
@@ -276,6 +287,23 @@ class RectangleShape extends PositionComponent
 
     if (order != null) {
       _addOrderBadge(order!);
+    }
+
+    if (!isDark && count >= 1) {
+      _hpTextComponent = TextComponent(
+        text: count.toString(),
+        anchor: Anchor.topRight,
+        position: Vector2(size.x - 4, 4),
+        priority: 999,
+        textRenderer: TextPaint(
+          style: const TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+            color: Colors.black,
+          ),
+        ),
+      );
+      add(_hpTextComponent!);
     }
 
     if (_usesPngLayer) {
@@ -399,34 +427,8 @@ class RectangleShape extends PositionComponent
     _renderSliceLine(canvas);
   }
 
-  void _renderRectangleShape(Canvas canvas) {
-    if (!isDark && count >= 1) {
-      _drawText(canvas, count.toString());
-    }
-  }
+  void _renderRectangleShape(Canvas canvas) {}
 
-  void _drawText(Canvas canvas, String text) {
-    final textPainter = TextPainter(
-      text: TextSpan(
-        text: text,
-        style: TextStyle(
-          color: const Color(0xFF4680FF)
-              .withAlpha((_blinkAlpha * 255).toInt()),
-          fontSize: 20,
-        ),
-      ),
-      textDirection: TextDirection.ltr,
-    )..layout();
-
-    final offset = Offset(
-      (size.x - textPainter.width) / 2,
-      (size.y - textPainter.height) / 2,
-    );
-
-    canvas.save();
-    textPainter.paint(canvas, offset);
-    canvas.restore();
-  }
 
   void _renderSliceLine(Canvas canvas) {
     if (sliceStart != null && sliceEnd != null) {
@@ -801,6 +803,13 @@ class RectangleShape extends PositionComponent
   void applyValidInteraction() {
     print("=== VALID MOVE ==============");
     count--;
+
+    if (count >= 1) {
+      _hpTextComponent?.text = count.toString();
+    } else {
+      _hpTextComponent?.removeFromParent();
+      _hpTextComponent = null;
+    }
 
     Future.delayed(const Duration(milliseconds: 1), () {
       isSliced = false;

--- a/lib/src/components/TriangleShape.dart
+++ b/lib/src/components/TriangleShape.dart
@@ -16,6 +16,7 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
   late final SvgComponent svg;
   int energy = 0;
   late final SpriteComponent _png;
+  TextComponent? _hpTextComponent;
 
   final bool isDark;
   final VoidCallback? onForbiddenTouch;
@@ -68,6 +69,10 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
 
     svg.opacity = _blinkAlpha;
     _png.opacity = _blinkAlpha;
+
+    _hpTextComponent?.textRenderer = TextPaint(
+      style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Colors.black.withValues(alpha: _blinkAlpha)),
+    );
   }
 
   // ===== 사라짐 애니메이션 상태 (유저 제거용) =====
@@ -156,6 +161,19 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
     _outlinePath = _buildTrianglePath(size.toSize());
     _outlineLength =
         _outlinePath.computeMetrics().fold(0.0, (sum, m) => sum + m.length);
+
+    if (!isDark && energy > 0) {
+      _hpTextComponent = TextComponent(
+        text: energy.toString(),
+        anchor: Anchor.topRight,
+        position: Vector2(size.x - 4, 4),
+        priority: 999,
+        textRenderer: TextPaint(
+          style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Colors.black),
+        ),
+      );
+      add(_hpTextComponent!);
+    }
   }
 
   // ==========================================================
@@ -167,9 +185,12 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
     // 에너지가 남아있으면 1 깎고 리턴 (아직 살아있음)
     if (energy > 1) {
       energy--;
+      _hpTextComponent?.text = energy.toString();
       return;
     }
 
+    _hpTextComponent?.removeFromParent();
+    _hpTextComponent = null;
     _isDisappearing = true;
     wasRemovedByUser = true;
 
@@ -275,11 +296,6 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
   void render(Canvas canvas) {
     super.render(canvas);
 
-    // 에너지 숫자 표시 (일반 삼각형이고 energy >= 1이면)
-    if (!isDark && energy >= 1 && !_isDisappearing) {
-      _drawText(canvas, energy.toString());
-    }
-
     if ((attackTime ?? 0) > 0 && !_attackDone && !_isDisappearing) {
       final ratio =
           ((attackTime! - _attackElapsed) / attackTime!).clamp(0.0, 1.0);
@@ -290,30 +306,6 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
       final partial = _extractPartialPath(_outlinePath, drawLen);
       canvas.drawPath(partial, _attackPaint);
     }
-  }
-
-  void _drawText(Canvas canvas, String text) {
-    final textPainter = TextPainter(
-      text: TextSpan(
-        text: text,
-        style: TextStyle(
-          color: baseColor.withValues(alpha: _blinkAlpha),
-          fontSize: 18,
-          fontWeight: FontWeight.bold,
-        ),
-      ),
-      textDirection: TextDirection.ltr,
-    )..layout();
-
-    // 삼각형 중심 약간 위쪽에 위치 (시각적 중심)
-    final offset = Offset(
-      (size.x - textPainter.width) / 2,
-      (size.y - textPainter.height) / 2 - 4,
-    );
-
-    canvas.save();
-    textPainter.paint(canvas, offset);
-    canvas.restore();
   }
 
   Path _buildTrianglePath(Size s) {

--- a/lib/src/components/TriangleShape.dart
+++ b/lib/src/components/TriangleShape.dart
@@ -162,7 +162,7 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
     _outlineLength =
         _outlinePath.computeMetrics().fold(0.0, (sum, m) => sum + m.length);
 
-    if (!isDark && energy > 0) {
+    if (!isDark && energy > 1) {
       _hpTextComponent = TextComponent(
         text: energy.toString(),
         anchor: Anchor.topRight,
@@ -185,7 +185,12 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
     // 에너지가 남아있으면 1 깎고 리턴 (아직 살아있음)
     if (energy > 1) {
       energy--;
-      _hpTextComponent?.text = energy.toString();
+      if (energy > 1) {
+        _hpTextComponent?.text = energy.toString();
+      } else {
+        _hpTextComponent?.removeFromParent();
+        _hpTextComponent = null;
+      }
       return;
     }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -180,18 +180,18 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: "6b6f10f0ce3c42f6552d1c70d2c28d764cf22bb487f50f66cca31dcd5194f4d6"
+      sha256: ba03d03bcaa2f6cb7bd920e3b5027181db75ab524f8891c8bc3aa603885b8055
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.4"
+    version: "6.3.3"
   http:
     dependency: "direct main"
     description:
       name: http
-      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.6"
+    version: "1.6.0"
   http_parser:
     dependency: transitive
     description:
@@ -244,18 +244,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -465,10 +465,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,8 +34,8 @@ dependencies:
     sdk: flutter
   flutter_svg: any
   flutter_dotenv: ^5.0.2
-  http: ^0.13.6
-  google_fonts: ^4.0.4
+  http: ^1.0.0
+  google_fonts: ^6.2.1
   carousel_slider: ^5.0.0
   shared_preferences: ^2.1.1
   go_router: ^14.0.2


### PR DESCRIPTION
- Show remaining hit count as black TextComponent child (priority 999) on Circle, Rectangle, Triangle, Hexagon, Pentagon
- TextComponent renders above SVG/PNG sprites, fixing coverage issue
- HP text updates on each hit and removes when count reaches 0
- Upgrade google_fonts 4.0.4 → 6.3.3 and http 0.13.6 → 1.0.0 to fix iOS build failure (Dart constant evaluation error)
- Add platform dirs and auto-generated files to .gitignore