### PR TITLE
Add hand-drawn wobble effect and fix shape rendering bugs

### DIFF
--- a/lib/src/components/CircleShape.dart
+++ b/lib/src/components/CircleShape.dart
@@ -9,6 +9,7 @@ import '../functions/OrderableShape.dart';
 import '../functions/OverlapHighlightable.dart';
 import '../effect/AttackExplosionEffect.dart';
 import '../effect/CircleDisappearEffect.dart';
+import 'shape_path_utils.dart';
 
 class CircleShape extends PositionComponent
     with TapCallbacks, UserRemovable, HasGameRef, OverlapHighlightable, BlinkAlphaTarget
@@ -30,6 +31,8 @@ class CircleShape extends PositionComponent
 
   late PositionComponent _orderBadge;
   TextComponent? _hpTextComponent;
+
+  late Path _wobblePath;
 
   double _attackElapsed = 0.0;
   bool _attackDone = false;
@@ -99,6 +102,8 @@ class CircleShape extends PositionComponent
       );
       add(_hpTextComponent!);
     }
+
+    _wobblePath = ShapePathUtils.wobble(_buildCirclePath(), amplitude: size.x * 0.009);
   }
 
   @override
@@ -160,31 +165,25 @@ class CircleShape extends PositionComponent
 
   @override
   void render(Canvas canvas) {
-    final center = Offset(size.x / 2, size.y / 2);
-    final radius = size.x * 0.45;
     final fillColor = isDark ? const Color(0xFF888888) : baseColor;
-    final shadowPath = Path()
-      ..addOval(Rect.fromCircle(center: center, radius: radius));
 
     canvas.drawShadow(
-      shadowPath,
+      _wobblePath,
       Colors.black.withValues(alpha: 0.28),
       5,
       false,
     );
 
-    canvas.drawCircle(
-      center,
-      radius,
+    canvas.drawPath(
+      _wobblePath,
       Paint()
         ..color = fillColor.withValues(alpha: _blinkAlpha)
         ..style = PaintingStyle.fill
         ..blendMode = blendMode,
     );
 
-    canvas.drawCircle(
-      center,
-      radius,
+    canvas.drawPath(
+      _wobblePath,
       Paint()
         ..color = Colors.black.withValues(alpha: _blinkAlpha * 0.14)
         ..style = PaintingStyle.stroke
@@ -193,9 +192,8 @@ class CircleShape extends PositionComponent
     );
 
     if (!_attackDone && _attackTimeCritical) {
-      canvas.drawCircle(
-        center,
-        radius,
+      canvas.drawPath(
+        _wobblePath,
         Paint()
           ..color = dangerColor.withValues(alpha: _blinkAlpha * 0.5)
           ..blendMode = BlendMode.srcATop,

--- a/lib/src/components/CircleShape.dart
+++ b/lib/src/components/CircleShape.dart
@@ -41,7 +41,7 @@ class CircleShape extends PositionComponent
     ..style = PaintingStyle.stroke
     ..strokeWidth = 6;
 
-  final Color baseColor = const Color(0xFFF45B3A);
+  final Color baseColor = const Color(0xFFED613D);
   final Color dangerColor = const Color(0xFFEE0505);
 
   double _blinkAlpha = 1.0;

--- a/lib/src/components/HexagonShape.dart
+++ b/lib/src/components/HexagonShape.dart
@@ -37,6 +37,7 @@ class HexagonShape extends PositionComponent
   bool _penaltyFired = false;
 
   late Path _outlinePath;
+  late Path _wobblePath;
   late double _outlineLength;
 
   final Paint _attackPaint = Paint()
@@ -110,6 +111,7 @@ class HexagonShape extends PositionComponent
 
     _outlineLength =
         _outlinePath.computeMetrics().fold(0.0, (s, m) => s + m.length);
+    _wobblePath = ShapePathUtils.wobble(_outlinePath, amplitude: size.x * 0.009);
 
     if (!isDark && energy >= 1) {
       _hpTextComponent = TextComponent(
@@ -296,14 +298,14 @@ class HexagonShape extends PositionComponent
     final alpha = (_blinkAlpha * _opacity).clamp(0.0, 1.0);
 
     canvas.drawShadow(
-      _outlinePath,
+      _wobblePath,
       Colors.black.withValues(alpha: 0.35),
       6,
       false,
     );
 
     canvas.drawPath(
-      _outlinePath,
+      _wobblePath,
       Paint()
         ..color = fillColor.withValues(alpha: alpha)
         ..style = PaintingStyle.fill
@@ -311,7 +313,7 @@ class HexagonShape extends PositionComponent
     );
 
     canvas.drawPath(
-      _outlinePath,
+      _wobblePath,
       Paint()
         ..color = fillColor.withValues(alpha: alpha * 0.8)
         ..style = PaintingStyle.stroke
@@ -327,7 +329,7 @@ class HexagonShape extends PositionComponent
 
       if (ratio <= 0.2) {
         canvas.drawPath(
-          _outlinePath,
+          _wobblePath,
           Paint()
             ..color = dangerColor.withValues(alpha: alpha * 0.5)
             ..style = PaintingStyle.fill

--- a/lib/src/components/HexagonShape.dart
+++ b/lib/src/components/HexagonShape.dart
@@ -42,13 +42,13 @@ class HexagonShape extends PositionComponent
   final Paint _attackPaint = Paint()
     ..style = PaintingStyle.stroke
     ..strokeWidth = 6
-    ..color = const Color(0xFF9BEE3B);
+    ..color = const Color(0xFF398A63);
 
-  static const Color outlineNormal = Color(0xFF9BEE3B);
+  static const Color outlineNormal = Color(0xFF398A63);
   static const Color outlineDanger = Color(0xFFEE0505);
 
   final Color dangerColor = const Color(0xFFEE0505);
-  final Color baseColor   = const Color(0xFF9BEE3B);
+  final Color baseColor   = const Color(0xFF398A63);
 
   final Paint _overlapOutlinePaint = Paint()
     ..color = Colors.black
@@ -226,7 +226,7 @@ class HexagonShape extends PositionComponent
             basePath: _buildExplosionHexagonPath(),
             position: position.clone(),
             size: size.clone(),
-            color: const Color(0xFF9BEE3B),
+            color: const Color(0xFF398A63),
           ),
         );
 
@@ -281,7 +281,7 @@ class HexagonShape extends PositionComponent
             basePath: _buildExplosionHexagonPath(),
             position: position.clone(),
             size: size.clone(),
-            color: const Color(0xFF9BEE3B),
+            color: const Color(0xFF398A63),
           ),
         );
 

--- a/lib/src/components/PentagonShape.dart
+++ b/lib/src/components/PentagonShape.dart
@@ -104,6 +104,7 @@ class PentagonShape extends PositionComponent
     ..color = const Color(0xFFF6B4B9);
 
   late Path _pentagonPath;
+  late Path _wobblePath;
   late double _perimeter;
 
   final Color baseColor = const Color(0xFFF6B4B9);
@@ -145,6 +146,7 @@ class PentagonShape extends PositionComponent
 
     _perimeter =
         _pentagonPath.computeMetrics().fold(0.0, (s, m) => s + m.length);
+    _wobblePath = ShapePathUtils.wobble(_pentagonPath, amplitude: size.x * 0.009);
 
     if (!isDark && energy >= 1) {
       _hpTextComponent = TextComponent(
@@ -256,14 +258,14 @@ class PentagonShape extends PositionComponent
     final fillColor = isDark ? const Color(0xFF888888) : baseColor;
 
     canvas.drawShadow(
-      _pentagonPath,
+      _wobblePath,
       Colors.black.withValues(alpha: 0.35),
       6,
       false,
     );
 
     canvas.drawPath(
-      _pentagonPath,
+      _wobblePath,
       Paint()
         ..color = fillColor.withValues(alpha: _blinkAlpha)
         ..style = PaintingStyle.fill
@@ -271,7 +273,7 @@ class PentagonShape extends PositionComponent
     );
 
     canvas.drawPath(
-      _pentagonPath,
+      _wobblePath,
       Paint()
         ..color = fillColor.withValues(alpha: _blinkAlpha * 0.8)
         ..style = PaintingStyle.stroke
@@ -287,7 +289,7 @@ class PentagonShape extends PositionComponent
 
       if (ratio <= 0.2) {
         canvas.drawPath(
-          _pentagonPath,
+          _wobblePath,
           Paint()
             ..color = dangerColor.withValues(alpha: _blinkAlpha * 0.5)
             ..style = PaintingStyle.fill

--- a/lib/src/components/PentagonShape.dart
+++ b/lib/src/components/PentagonShape.dart
@@ -150,7 +150,7 @@ class PentagonShape extends PositionComponent
       _hpTextComponent = TextComponent(
         text: energy.toString(),
         anchor: Anchor.center,
-        position: size / 2,
+        position: Vector2(_visualPentagonCenter.dx, _visualPentagonCenter.dy),
         priority: 999,
         textRenderer: TextPaint(
           style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Colors.black),

--- a/lib/src/components/PentagonShape.dart
+++ b/lib/src/components/PentagonShape.dart
@@ -92,7 +92,7 @@ class PentagonShape extends PositionComponent
 
   final Paint _circlePaint = Paint()
     ..style = PaintingStyle.fill
-    ..color = const Color(0xFFFFA6FC);
+    ..color = const Color(0xFFF6B4B9);
 
   // ===============================
   // ATTACK
@@ -101,12 +101,12 @@ class PentagonShape extends PositionComponent
   final Paint _attackPaint = Paint()
     ..style = PaintingStyle.stroke
     ..strokeWidth = 6
-    ..color = const Color(0xFFFFA6FC);
+    ..color = const Color(0xFFF6B4B9);
 
   late Path _pentagonPath;
   late double _perimeter;
 
-  final Color baseColor = const Color(0xFFFFA6FC);
+  final Color baseColor = const Color(0xFFF6B4B9);
   final Color dangerColor = const Color(0xFFEE0505);
 
   PentagonShape(

--- a/lib/src/components/RectangleShape.dart
+++ b/lib/src/components/RectangleShape.dart
@@ -47,6 +47,7 @@ class RectangleShape extends PositionComponent
   bool isPaused = false;
 
   late Path _outlinePath;
+  late Path _wobblePath;
   late double _outlineLength;
 
   final Paint _attackPaint = Paint()
@@ -142,6 +143,7 @@ class RectangleShape extends PositionComponent
     _outlinePath = _buildRectPath(size.toSize());
     _outlineLength =
         _outlinePath.computeMetrics().fold(0.0, (sum, m) => sum + m.length);
+    _wobblePath = ShapePathUtils.wobble(_outlinePath, amplitude: size.x * 0.009);
   }
 
   Path _buildRectPath(Size s) {
@@ -235,14 +237,14 @@ class RectangleShape extends PositionComponent
     final fillColor = isDark ? const Color(0xFF555555) : baseColor;
 
     canvas.drawShadow(
-      _outlinePath,
+      _wobblePath,
       Colors.black.withValues(alpha: 0.35),
       6,
       false,
     );
 
     canvas.drawPath(
-      _outlinePath,
+      _wobblePath,
       Paint()
         ..color = fillColor.withValues(alpha: _blinkAlpha)
         ..style = PaintingStyle.fill
@@ -250,7 +252,7 @@ class RectangleShape extends PositionComponent
     );
 
     canvas.drawPath(
-      _outlinePath,
+      _wobblePath,
       Paint()
         ..color = fillColor.withValues(alpha: _blinkAlpha * 0.8)
         ..style = PaintingStyle.stroke
@@ -262,7 +264,7 @@ class RectangleShape extends PositionComponent
 
     if (!_attackDone && _attackTimeHalfLeft) {
       canvas.drawPath(
-        _outlinePath,
+        _wobblePath,
         Paint()
           ..color = dangerColor.withValues(alpha: _blinkAlpha * 0.5)
           ..style = PaintingStyle.fill

--- a/lib/src/components/TriangleShape.dart
+++ b/lib/src/components/TriangleShape.dart
@@ -100,10 +100,11 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
         _outlinePath.computeMetrics().fold(0.0, (sum, m) => sum + m.length);
 
     if (!isDark && energy >= 1) {
+      // centroid of SVG triangle (top:3.5, bot:78.5 on 86h grid) = y * (3.5+78.5+78.5)/(86*3)
       _hpTextComponent = TextComponent(
         text: energy.toString(),
         anchor: Anchor.center,
-        position: size / 2,
+        position: Vector2(size.x / 2, size.y * (3.5 + 78.5 * 2) / (86 * 3)),
         priority: 999,
         textRenderer: TextPaint(
           style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Colors.black),

--- a/lib/src/components/TriangleShape.dart
+++ b/lib/src/components/TriangleShape.dart
@@ -69,9 +69,9 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
     ..strokeWidth = 6
     ..strokeJoin = StrokeJoin.round
     ..strokeCap = StrokeCap.round
-    ..color = const Color(0xFFFFD84D);
+    ..color = const Color(0xFFF2AC32);
 
-  final Color baseColor = const Color(0xFFFFD84D);
+  final Color baseColor = const Color(0xFFF2AC32);
   final Color dangerColor = const Color(0xFFEE0505);
 
   TriangleShape(
@@ -211,7 +211,7 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
           basePath: _buildExplosionTrianglePath(),   // 삼각형 외곽 그대로 사용
           position: position.clone(),
           size: size.clone(),
-          color: const Color(0xFFFFD84D),
+          color: const Color(0xFFF2AC32),
         ),
       );
 

--- a/lib/src/components/TriangleShape.dart
+++ b/lib/src/components/TriangleShape.dart
@@ -62,6 +62,7 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
   double _rotDir = 1.0;
 
   late Path _outlinePath;
+  late Path _wobblePath;
   late double _outlineLength;
 
   final Paint _attackPaint = Paint()
@@ -98,6 +99,7 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
     _outlinePath = _buildTrianglePath(size.toSize());
     _outlineLength =
         _outlinePath.computeMetrics().fold(0.0, (sum, m) => sum + m.length);
+    _wobblePath = ShapePathUtils.wobble(_outlinePath, amplitude: size.x * 0.009);
 
     if (!isDark && energy >= 1) {
       // centroid of SVG triangle (top:3.5, bot:78.5 on 86h grid) = y * (3.5+78.5+78.5)/(86*3)
@@ -234,14 +236,14 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
     final alpha = (_blinkAlpha * _shapeOpacity).clamp(0.0, 1.0);
 
     canvas.drawShadow(
-      _outlinePath,
+      _wobblePath,
       Colors.black.withValues(alpha: 0.35),
       6,
       false,
     );
 
     canvas.drawPath(
-      _outlinePath,
+      _wobblePath,
       Paint()
         ..color = fillColor.withValues(alpha: alpha)
         ..style = PaintingStyle.fill
@@ -249,7 +251,7 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
     );
 
     canvas.drawPath(
-      _outlinePath,
+      _wobblePath,
       Paint()
         ..color = fillColor.withValues(alpha: alpha * 0.8)
         ..style = PaintingStyle.stroke
@@ -261,7 +263,7 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
 
     if (!_attackDone && _attackTimeHalfLeft) {
       canvas.drawPath(
-        _outlinePath,
+        _wobblePath,
         Paint()
           ..color = dangerColor.withValues(alpha: alpha * 0.5)
           ..style = PaintingStyle.fill

--- a/lib/src/components/shape_path_utils.dart
+++ b/lib/src/components/shape_path_utils.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'dart:ui';
 
 class ShapePathUtils {
@@ -15,5 +16,55 @@ class ShapePathUtils {
     }
 
     return result;
+  }
+
+  // Figma Dynamic stroke: Frequency 136%, Wiggle 25%, Smoothen 83%
+  // Multi-harmonic approach: low + mid + high frequency waves combined
+  // for organic, irregular hand-drawn feel.
+  static Path wobble(
+    Path source, {
+    double amplitude = 4,
+  }) {
+    final pts = <Offset>[];
+
+    for (final metric in source.computeMetrics()) {
+      final len = metric.length;
+      // Steps must be ≥ 2× highest frequency to represent waves (Nyquist)
+      final steps = max(80, (len / 3.5).round());
+      for (var i = 0; i < steps; i++) {
+        final progress = i / steps;
+        final t = progress * len;
+        final tan = metric.getTangentForOffset(t);
+        if (tan == null) continue;
+        final nx = -tan.vector.dy;
+        final ny = tan.vector.dx;
+        // Coprime frequencies → irregular, non-repeating pattern
+        final wave = amplitude * (
+          0.50 * sin(progress * 2 * pi * 11) +
+          0.32 * sin(progress * 2 * pi * 19 + 1.1) +
+          0.18 * sin(progress * 2 * pi * 29 + 2.6)
+        );
+        pts.add(Offset(
+          tan.position.dx + nx * wave,
+          tan.position.dy + ny * wave,
+        ));
+      }
+    }
+
+    if (pts.isEmpty) return source;
+
+    // Catmull-Rom spline: smooth curves through all wobble points
+    final n = pts.length;
+    final result = Path()..moveTo(pts[0].dx, pts[0].dy);
+    for (var i = 0; i < n; i++) {
+      final p0 = pts[(i - 1 + n) % n];
+      final p1 = pts[i];
+      final p2 = pts[(i + 1) % n];
+      final p3 = pts[(i + 2) % n];
+      final cp1 = Offset(p1.dx + (p2.dx - p0.dx) / 5, p1.dy + (p2.dy - p0.dy) / 5);
+      final cp2 = Offset(p2.dx - (p3.dx - p1.dx) / 5, p2.dy - (p3.dy - p1.dy) / 5);
+      result.cubicTo(cp1.dx, cp1.dy, cp2.dx, cp2.dy, p2.dx, p2.dy);
+    }
+    return result..close();
   }
 }

--- a/lib/src/functions/sheet_service.dart
+++ b/lib/src/functions/sheet_service.dart
@@ -52,6 +52,8 @@ class SheetService {
       throw Exception('Sheet fetch failed: ${res.statusCode}');
     }
 
+    debugPrint('[SHEET RAW] $name: ${res.body.substring(0, res.body.length.clamp(0, 300))}');
+
     final data = jsonDecode(res.body);
     final values = (data['values'] as List).cast<List<dynamic>>();
 

--- a/lib/src/functions/sheet_service.dart
+++ b/lib/src/functions/sheet_service.dart
@@ -159,9 +159,8 @@ class SheetService {
       final ctx = missionContexts[currentMission]!;
 
       final shapeColumn = _shapeColumnIndex(cells);
+      if (shapeColumn < 0) continue;
       final rawShapeCell = _safeGet(cells, shapeColumn);
-      if (rawShapeCell.isEmpty) continue;
-      if (_isHeaderShape(rawShapeCell)) continue;
 
       final isWait = rawShapeCell.toLowerCase().startsWith('wait');
       final command = isWait ? 'wait' : 'e';
@@ -247,13 +246,10 @@ class SheetService {
   }
 
   int _shapeColumnIndex(List<String> cells) {
-    final newShapeCell = _safeGet(cells, 1);
-    if (_isShapeOrWaitCell(newShapeCell)) return 1;
-
-    final legacyShapeCell = _safeGet(cells, 2);
-    if (_isShapeOrWaitCell(legacyShapeCell)) return 2;
-
-    return 1;
+    if (_isShapeOrWaitCell(_safeGet(cells, 1))) return 1;
+    if (_isShapeOrWaitCell(_safeGet(cells, 2))) return 2;
+    if (_isShapeOrWaitCell(_safeGet(cells, 3))) return 3;
+    return -1;
   }
 
   bool _isHeaderShape(String value) {

--- a/lib/src/routes/OneSecondGame.dart
+++ b/lib/src/routes/OneSecondGame.dart
@@ -1441,7 +1441,11 @@ class OneSecondGame extends FlameGame
       _isContinuing = false;
       _lastRoundStartIndex = 0;
 
-      if (_isPausedGlobally) return;
+      if (_isPausedGlobally) {
+        _refreshCompleter?.complete();
+        _refreshCompleter = null;
+        return;
+      }
 
       debugPrint("Refreshing Game...");
 


### PR DESCRIPTION
## Summary
- Add multi-harmonic wobble effect to all 5 shapes (Circle, Triangle, Rectangle, Pentagon, Hexagon) for hand-drawn organic border feel
- Fix shape colors to match design spec (Circle #ED613D, Triangle #F2AC32, Rectangle #345983, Pentagon #F6B4B9, Hexagon #398A63)
- Fix HP text alignment on Triangle and Pentagon shapes
- Fix sheet parsing to correctly detect shape column (cols 1–3) and skip non-shape rows
- Fix `onRefresh()` early return not completing `_refreshCompleter` when game is paused

## Wobble settings
- Frequencies: 11/19/29 Hz (coprime, multi-harmonic) for irregular organic feel
- Catmull-Rom spline with 80+ sample points for smooth fluid curves
- Per-shape amplitude: `size.x * 0.009`

## Test plan
- [x] All 5 shapes render with wobbly borders
- [x] HP text centered on all shapes
- [x] Shape colors match design spec
- [x] Game starts with enemies visible (no blank screen)
- [ ] Refresh button fetches latest Google Sheet data
