### PR TITLE
Add rotation angle support for Rectangle shapes

### DIFF
--- a/lib/src/components/PreparedEnemy.dart
+++ b/lib/src/components/PreparedEnemy.dart
@@ -12,6 +12,7 @@ class PreparedEnemy {
   final double? attackTime;
   final double? attackDamage;
   final ShapeBehavior? behavior;
+  final double angle;
 
   const PreparedEnemy({
     required this.shapeType,
@@ -23,6 +24,7 @@ class PreparedEnemy {
     required this.order,
     required this.behavior,
     required this.customSize,
+    this.angle = 0.0,
   });
 
   @override

--- a/lib/src/components/RectangleShape.dart
+++ b/lib/src/components/RectangleShape.dart
@@ -78,10 +78,12 @@ class RectangleShape extends PositionComponent
     this.onRemoved,
     this.onInteracted,
     this.blendMode = BlendMode.srcOver,
+    double angle = 0.0,
   }) : super(
           position: position,
           size: customSize ?? Vector2(40, 80),
           anchor: Anchor.center,
+          angle: angle,
         );
 
   void setBlinkAlpha(double alpha) {

--- a/lib/src/routes/OneSecondGame.dart
+++ b/lib/src/routes/OneSecondGame.dart
@@ -728,17 +728,7 @@ class OneSecondGame extends FlameGame
       shapeType = "Circle";
 
     } else if (enemy.shape.startsWith('Rectangle')) {
-      // Rectangle은 직접 크기 지정이 있거나, 없으면 스케일 적용
       size = _parseRectSize(enemy.shape) ?? Vector2(40, 80);
-
-      // 만약 Rectangle2 처럼 스케일만 적혀있다면 기본(40,80)에 스케일 적용
-      if (_parseRectSize(enemy.shape) == null) {
-        final scale = _parseScale(enemy.shape);
-        // 기본값이 Rectangle4라고 가정하면 scale 1.0 -> 40,80
-        // Rectangle2 -> scale 0.5 -> 20,40
-        size = Vector2(40 * scale, 80 * scale);
-      }
-
       shapeType = "Rectangle";
       rectAngle = _parseRectAngle(enemy.shape);
 

--- a/lib/src/routes/OneSecondGame.dart
+++ b/lib/src/routes/OneSecondGame.dart
@@ -717,6 +717,7 @@ class OneSecondGame extends FlameGame
     // 1. 도형 & 사이즈 파싱
     String shapeType = "";
     Vector2 size = Vector2.zero();
+    double rectAngle = 0.0;
     debugPrint("[PreparedEnemy] enemy name : ${enemy.shape}");
     if (enemy.shape.startsWith('Circle')) {
       final scale = _parseScale(enemy.shape);
@@ -739,6 +740,7 @@ class OneSecondGame extends FlameGame
       }
 
       shapeType = "Rectangle";
+      rectAngle = _parseRectAngle(enemy.shape);
 
     } else if (enemy.shape.startsWith('Pentagon')) {
       final scale = _parseScale(enemy.shape);
@@ -813,6 +815,7 @@ class OneSecondGame extends FlameGame
       behavior: behavior,
       attackTime: enemy.attackSeconds,
       attackDamage: enemy.attackDamage,
+      angle: rectAngle,
     );
   }
 
@@ -879,6 +882,7 @@ class OneSecondGame extends FlameGame
           customSize: enemy.customSize,
           order: enemy.order,
           onInteracted: _onOrderInteracted,
+          angle: enemy.angle,
         );
 
       case "Triangle":
@@ -943,7 +947,7 @@ class OneSecondGame extends FlameGame
     return 1.0; // 기본값 (Circle == Circle4)
   }
 
-  // 2) Rectangle 직접 크기 파싱 (Rectangle40:200)
+  // 2) Rectangle 직접 크기 파싱 (Rectangle40:200 or Rectangle40:200@45)
   Vector2? _parseRectSize(String s) {
     final m = RegExp(r'Rectangle(\d+):(\d+)').firstMatch(s);
     if (m != null) {
@@ -953,6 +957,16 @@ class OneSecondGame extends FlameGame
       return Vector2(w, h);
     }
     return null;
+  }
+
+  // 3) Rectangle 회전 각도 파싱 (Rectangle4@45, Rectangle40:200@-30)
+  double _parseRectAngle(String s) {
+    final m = RegExp(r'@(-?\d+(?:\.\d+)?)').firstMatch(s);
+    if (m != null) {
+      final degrees = double.parse(m.group(1)!);
+      return degrees * math.pi / 180;
+    }
+    return 0.0;
   }
 
   ShapeBehavior? checkBehavior(

--- a/lib/src/routes/OneSecondGame.dart
+++ b/lib/src/routes/OneSecondGame.dart
@@ -959,9 +959,9 @@ class OneSecondGame extends FlameGame
     return null;
   }
 
-  // 3) Rectangle 회전 각도 파싱 (Rectangle4@45, Rectangle40:200@-30)
+  // 3) Rectangle 회전 각도 파싱 (Rectangle4/45, Rectangle40:200/-30)
   double _parseRectAngle(String s) {
-    final m = RegExp(r'@(-?\d+(?:\.\d+)?)').firstMatch(s);
+    final m = RegExp(r'/(-?\d+(?:\.\d+)?)').firstMatch(s);
     if (m != null) {
       final degrees = double.parse(m.group(1)!);
       return degrees * math.pi / 180;


### PR DESCRIPTION
## Summary

- Add rotation angle support for Rectangle shapes via \`/angle\` syntax
- Remove scale-based presets (Rectangle2, Rectangle4, etc.)
- Rectangle now supports two formats only:
  - \`Rectangle\` → default 40×80
  - \`Rectangle40:200\` → explicit width×height
  - \`Rectangle40:200/45\` → explicit size with rotation angle

## Breaking Change

\`Rectangle2\`, \`Rectangle4\`, etc. (scale presets) are no longer supported — they now fall back to default 40×80. Update sheet entries to use explicit size format (e.g. \`Rectangle40:200\`).

## Test plan

- [x] \`Rectangle\` → 40×80, no rotation
- [x] \`Rectangle40:200\` → 40×200, no rotation
- [x] \`Rectangle40:200/45\` → 40×200, rotated 45 degrees
- [x] \`Rectangle40:200/-30\` → 40×200, rotated -30 degrees
- [x] \`Rectangle4\` (old scale preset) → falls back to 40×80