### PR TITLE
fix: preserve stage carousel position when navigating back from mission select

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -102,8 +102,14 @@ class figureoutMain extends StatelessWidget {
         GoRoute(
           path: '/stages',
           builder: (context, state) {
-            final data = state.extra as List<StageData>;
-            return StageSelectScreen(stages: data);
+            final extra = state.extra;
+            if (extra is StageRouteArgs) {
+              return StageSelectScreen(
+                stages: extra.stages,
+                initialStageIndex: extra.initialStageIndex,
+              );
+            }
+            return StageSelectScreen(stages: extra as List<StageData>);
           },
         ),
         GoRoute(

--- a/lib/src/routes/MissionSelect.dart
+++ b/lib/src/routes/MissionSelect.dart
@@ -264,8 +264,13 @@ class _MissionSelectScreenState extends State<MissionSelectScreen> {
                 Align(
                   alignment: Alignment.centerLeft,
                   child: GestureDetector(
-                    onTap: () =>
-                        context.push('/stages', extra: stages),
+                    onTap: () => context.push(
+                      '/stages',
+                      extra: StageRouteArgs(
+                        stages: stages,
+                        initialStageIndex: widget.stageIndex,
+                      ),
+                    ),
                     child: SvgPicture.asset(
                       "assets/menu/common/Arrow_prev.svg",
                       width: 40,

--- a/lib/src/routes/StageSelect.dart
+++ b/lib/src/routes/StageSelect.dart
@@ -10,15 +10,20 @@ import 'route_args.dart';
 
 class StageSelectScreen extends StatefulWidget {
   final List<StageData> stages;
+  final int initialStageIndex;
 
-  const StageSelectScreen({super.key, required this.stages});
+  const StageSelectScreen({
+    super.key,
+    required this.stages,
+    this.initialStageIndex = 0,
+  });
 
   @override
   State<StageSelectScreen> createState() => _StageSelectScreenState();
 }
 
 class _StageSelectScreenState extends State<StageSelectScreen> {
-  int _currentIndex = 0;
+  late int _currentIndex;
 
   // SVG 파일 목록 (assets 폴더에 미리 넣어야 함)
   final List<String> stagesSVG = [
@@ -30,6 +35,12 @@ class _StageSelectScreenState extends State<StageSelectScreen> {
     "assets/menu/stage/stage_6.png",
     "assets/menu/stage/stage_7.png",
   ];
+
+  @override
+  void initState() {
+    super.initState();
+    _currentIndex = widget.initialStageIndex;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -52,6 +63,7 @@ class _StageSelectScreenState extends State<StageSelectScreen> {
                   enableInfiniteScroll: false,
                   padEnds: true,
                   autoPlay: false,
+                  initialPage: widget.initialStageIndex,
                   onPageChanged: (index, reason) {
                     setState(() => _currentIndex = index);
                   },

--- a/lib/src/routes/route_args.dart
+++ b/lib/src/routes/route_args.dart
@@ -1,5 +1,15 @@
 import '../functions/sheet_service.dart';
 
+class StageRouteArgs {
+  final List<StageData> stages;
+  final int initialStageIndex;
+
+  const StageRouteArgs({
+    required this.stages,
+    this.initialStageIndex = 0,
+  });
+}
+
 class MissionRouteArgs {
   final List<StageData> stages;
   final int stageIndex;


### PR DESCRIPTION
## Summary
- Fixed a bug where the stage carousel always reset to Stage 1 when navigating back from Mission Select
- Added `StageRouteArgs` class to carry `initialStageIndex` alongside the stages list
- `StageSelectScreen` now initializes the carousel to the correct position using the received index

## Root cause
The back button in `MissionSelect.dart` was only passing the `stages` list without `stageIndex`.
`StageSelectScreen` always initialized `_currentIndex = 0`, resetting the carousel position.

## Test plan
- [x] Select Stage 2 → enter Mission Select → press back → verify carousel lands on Stage 2
- [x] Repeat for Stages 1, 3, 4
- [x] Main menu → Stage Select entry starts at Stage 1 (index 0) as before