### PR TITLE
feat: add background-color border to separate overlapping shapes

### DIFF
--- a/lib/src/components/CircleShape.dart
+++ b/lib/src/components/CircleShape.dart
@@ -175,8 +175,22 @@ class CircleShape extends PositionComponent
     return point.distanceTo(center) <= radius;
   }
 
+  static const double _borderHalo = 0.08;
+  static const Color _borderColor = Color(0xFFE4E0D3);
+
   @override
   void render(Canvas canvas) {
+    _sprite.render(
+      canvas,
+      position: Vector2(-size.x * _borderHalo / 2, -size.y * _borderHalo / 2),
+      size: size * (1 + _borderHalo),
+      overridePaint: Paint()
+        ..colorFilter = ColorFilter.mode(
+          Color.fromARGB((_blinkAlpha * 255).round(), 0xE4, 0xE0, 0xD3),
+          BlendMode.srcIn,
+        ),
+    );
+
     _sprite.render(
       canvas,
       size: size,

--- a/lib/src/components/CircleShape.dart
+++ b/lib/src/components/CircleShape.dart
@@ -175,7 +175,7 @@ class CircleShape extends PositionComponent
     return point.distanceTo(center) <= radius;
   }
 
-  static const double _borderHalo = 0.08;
+  static const double _borderHalo = 0.05;
   static const Color _borderColor = Color(0xFFE4E0D3);
 
   @override

--- a/lib/src/components/HexagonShape.dart
+++ b/lib/src/components/HexagonShape.dart
@@ -323,7 +323,7 @@ class HexagonShape extends PositionComponent
     return count.isOdd;
   }
 
-  static const double _borderHalo = 0.08;
+  static const double _borderHalo = 0.05;
 
   @override
   void render(Canvas canvas) {

--- a/lib/src/components/HexagonShape.dart
+++ b/lib/src/components/HexagonShape.dart
@@ -323,9 +323,22 @@ class HexagonShape extends PositionComponent
     return count.isOdd;
   }
 
+  static const double _borderHalo = 0.08;
+
   @override
   void render(Canvas canvas) {
     final alpha = (_blinkAlpha * _opacity).clamp(0.0, 1.0);
+
+    _sprite.render(
+      canvas,
+      position: Vector2(-size.x * _borderHalo / 2, -size.y * _borderHalo / 2),
+      size: size * (1 + _borderHalo),
+      overridePaint: Paint()
+        ..colorFilter = ColorFilter.mode(
+          Color.fromARGB((alpha * 255).round(), 0xE4, 0xE0, 0xD3),
+          BlendMode.srcIn,
+        ),
+    );
 
     _sprite.render(
       canvas,

--- a/lib/src/components/PentagonShape.dart
+++ b/lib/src/components/PentagonShape.dart
@@ -283,7 +283,7 @@ class PentagonShape extends PositionComponent
     return count.isOdd;
   }
 
-  static const double _borderHalo = 0.08;
+  static const double _borderHalo = 0.05;
 
   @override
   void render(Canvas canvas) {

--- a/lib/src/components/PentagonShape.dart
+++ b/lib/src/components/PentagonShape.dart
@@ -283,8 +283,21 @@ class PentagonShape extends PositionComponent
     return count.isOdd;
   }
 
+  static const double _borderHalo = 0.08;
+
   @override
   void render(Canvas canvas) {
+    _sprite.render(
+      canvas,
+      position: Vector2(-size.x * _borderHalo / 2, -size.y * _borderHalo / 2),
+      size: size * (1 + _borderHalo),
+      overridePaint: Paint()
+        ..colorFilter = ColorFilter.mode(
+          Color.fromARGB((_blinkAlpha * 255).round(), 0xE4, 0xE0, 0xD3),
+          BlendMode.srcIn,
+        ),
+    );
+
     _sprite.render(
       canvas,
       size: size,

--- a/lib/src/components/RectangleShape.dart
+++ b/lib/src/components/RectangleShape.dart
@@ -247,7 +247,20 @@ class RectangleShape extends PositionComponent
            point.y >= inset && point.y <= size.y - inset;
   }
 
+  static const double _borderHalo = 0.08;
+
   void _renderRectangleShape(Canvas canvas) {
+    _sprite.render(
+      canvas,
+      position: Vector2(-size.x * _borderHalo / 2, -size.y * _borderHalo / 2),
+      size: size * (1 + _borderHalo),
+      overridePaint: Paint()
+        ..colorFilter = ColorFilter.mode(
+          Color.fromARGB((_blinkAlpha * 255).round(), 0xE4, 0xE0, 0xD3),
+          BlendMode.srcIn,
+        ),
+    );
+
     _sprite.render(
       canvas,
       size: size,

--- a/lib/src/components/RectangleShape.dart
+++ b/lib/src/components/RectangleShape.dart
@@ -247,7 +247,7 @@ class RectangleShape extends PositionComponent
            point.y >= inset && point.y <= size.y - inset;
   }
 
-  static const double _borderHalo = 0.08;
+  static const double _borderHalo = 0.05;
 
   void _renderRectangleShape(Canvas canvas) {
     _sprite.render(

--- a/lib/src/components/TriangleShape.dart
+++ b/lib/src/components/TriangleShape.dart
@@ -246,8 +246,21 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
   }
 
   @override
+  static const double _borderHalo = 0.08;
+
   void render(Canvas canvas) {
     final alpha = (_blinkAlpha * _shapeOpacity).clamp(0.0, 1.0);
+
+    _sprite.render(
+      canvas,
+      position: Vector2(-size.x * _borderHalo / 2, -size.y * _borderHalo / 2),
+      size: size * (1 + _borderHalo),
+      overridePaint: Paint()
+        ..colorFilter = ColorFilter.mode(
+          Color.fromARGB((alpha * 255).round(), 0xE4, 0xE0, 0xD3),
+          BlendMode.srcIn,
+        ),
+    );
 
     _sprite.render(
       canvas,

--- a/lib/src/components/TriangleShape.dart
+++ b/lib/src/components/TriangleShape.dart
@@ -246,7 +246,7 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
   }
 
   @override
-  static const double _borderHalo = 0.08;
+  static const double _borderHalo = 0.05;
 
   void render(Canvas canvas) {
     final alpha = (_blinkAlpha * _shapeOpacity).clamp(0.0, 1.0);


### PR DESCRIPTION
## Summary

When shapes overlap, it was hard to visually tell them apart. This PR adds a background-colored border around each shape to create a clear separation.
<img width="568" height="1084" alt="image" src="https://github.com/user-attachments/assets/edf71fdb-2591-41e3-b689-52147a0ed309" />

## How it works

Each shape sprite is rendered twice in sequence:

1. **Border layer** — same PNG rendered at 108% size, filled with the background color `#E4E0D3` using `BlendMode.srcIn`. This creates a silhouette that sticks out by ~4–6px around the actual shape.
2. **Sprite layer** — normal sprite rendered on top at 100% size.

The visible gap between the two layers forms the border. When shapes overlap, the top shape's border covers the edge of the shape underneath, creating a natural visual separator.

Border thickness is controlled by a single constant `_borderHalo = 0.08` per class — easy to tune.

## Shapes affected

- CircleShape
- TriangleShape
- RectangleShape
- PentagonShape
- HexagonShape