### PR TITLE
fix: reverse slide direction for back navigation

### DIFF
--- a/lib/src/routes/MissionSelect.dart
+++ b/lib/src/routes/MissionSelect.dart
@@ -243,13 +243,7 @@ class _MissionSelectScreenState extends State<MissionSelectScreen> {
                 child: Align(
                   alignment: Alignment.centerLeft,
                   child: GestureDetector(
-                    onTap: () => context.push(
-                      '/stages',
-                      extra: StageRouteArgs(
-                        stages: stages,
-                        initialStageIndex: widget.stageIndex,
-                      ),
-                    ),
+                    onTap: () => context.pop(),
                     child: Image.asset(
                       'assets/Back_button_beige.png',
                       width: 40,

--- a/lib/src/routes/OneSecondGame.dart
+++ b/lib/src/routes/OneSecondGame.dart
@@ -2574,10 +2574,7 @@ bool _isStraightLine(List<Vector2> path) {
 
   void handleAftermathMenu() {
     _removeAftermathOverlay();
-    rootNavigatorKey.currentContext!.push(
-      '/missions',
-      extra: MissionRouteArgs(stages: stages, stageIndex: _selectedStageIndex),
-    );
+    rootNavigatorKey.currentContext!.pop();
   }
 
   void handlePauseResume() => resumeGame();
@@ -2589,13 +2586,7 @@ bool _isStraightLine(List<Vector2> path) {
 
   void handlePauseMenu() {
     _removeAftermathOverlay();
-    rootNavigatorKey.currentContext!.push(
-      '/missions',
-      extra: MissionRouteArgs(
-        stages: stages,
-        stageIndex: _selectedStageIndex,
-      ),
-    );
+    rootNavigatorKey.currentContext!.pop();
   }
 
   void _drawDashedPath(


### PR DESCRIPTION
- Stage select slides in from left when pressing Back on mission select
- Mission select slides in from left when pressing Exit from play screen