### PR TITLE
feat: fetch fresh stage data on mission select

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,6 +26,10 @@ import 'package:figureout/src/routes/StageSelect.dart';
 import 'package:figureout/src/routes/route_args.dart';
 
 final GlobalKey<NavigatorState> rootNavigatorKey = GlobalKey<NavigatorState>();
+final RouteObserver<ModalRoute<void>> routeObserver = RouteObserver<ModalRoute<void>>();
+
+List<StageData> cachedStages = [];
+List<String> cachedStageSheetNames = [];
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -64,6 +68,21 @@ void main() async {
     translations,
   );
 
+  try {
+    final service = SheetService();
+    final allSheetNames = await service.fetchSheetNames().timeout(const Duration(seconds: 8));
+    final stageNames = allSheetNames
+        .where((n) => n.startsWith('Stage') || n.startsWith('Stages'))
+        .toList();
+    cachedStageSheetNames = stageNames.isNotEmpty ? stageNames : allSheetNames;
+    cachedStages = await service
+        .fetchData(preloadedSheetNames: allSheetNames)
+        .timeout(const Duration(seconds: 8));
+    debugPrint('[Sheet] Loaded ${cachedStages.length} stages at startup');
+  } catch (e) {
+    debugPrint('[Sheet] Initial fetch failed: $e');
+  }
+
   await SystemChrome.setPreferredOrientations([
     DeviceOrientation.portraitUp, // Lock to portrait orientation
   ]);
@@ -94,6 +113,7 @@ class figureoutMain extends StatelessWidget {
     final router = GoRouter(
       navigatorKey: rootNavigatorKey,
       initialLocation: '/',
+      observers: [routeObserver],
       routes: [
         GoRoute(
           path: '/',

--- a/lib/src/functions/sheet_service.dart
+++ b/lib/src/functions/sheet_service.dart
@@ -17,12 +17,12 @@ class SheetService {
   String get encodedSheetName => Uri.encodeComponent(sheetName);
   String get range => 'B1:I';
 
-  Future<List<StageData>> fetchData() async {
+  Future<List<StageData>> fetchData({List<String>? preloadedSheetNames}) async {
     if (sheetId.isEmpty || apiKey.isEmpty) {
       throw Exception('Missing Google Sheet credentials in .env');
     }
 
-    final sheetNames = await fetchSheetNames();
+    final sheetNames = preloadedSheetNames ?? await fetchSheetNames();
 
     final stageSheetNames = sheetNames
         .where((name) => name.startsWith('Stage') || name.startsWith('Stages'))
@@ -38,6 +38,11 @@ class SheetService {
     return results.expand((e) => e).toList();
   }
 
+  Future<StageData?> fetchSingleStage(String sheetName) async {
+    final results = await _fetchSingleSheet(sheetName);
+    return results.isNotEmpty ? results.first : null;
+  }
+
   Future<List<StageData>> _fetchSingleSheet(String name) async {
     final encoded = Uri.encodeComponent(name);
 
@@ -45,7 +50,7 @@ class SheetService {
       'https://sheets.googleapis.com/v4/spreadsheets/$sheetId/values/$encoded!$range?key=$apiKey',
     );
 
-    final res = await http.get(uri);
+    final res = await http.get(uri, headers: {'Cache-Control': 'no-cache'});
     if (res.statusCode != 200) {
       throw Exception('Sheet fetch failed: ${res.statusCode}');
     }
@@ -221,7 +226,7 @@ class SheetService {
       'https://sheets.googleapis.com/v4/spreadsheets/$sheetId?key=$apiKey',
     );
 
-    final res = await http.get(uri);
+    final res = await http.get(uri, headers: {'Cache-Control': 'no-cache'});
 
     if (res.statusCode != 200) {
       throw Exception('Sheet meta fetch failed: ${res.statusCode}');

--- a/lib/src/routes/MainMenu.dart
+++ b/lib/src/routes/MainMenu.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
 import 'package:figureout/src/functions/sheet_service.dart';
+import 'package:figureout/main.dart';
 import 'package:go_router/go_router.dart';
 
 import '../config.dart';
@@ -23,8 +24,6 @@ class _MainMenuScreenState extends State<MainMenuScreen>
 
   final SheetService sheetService = SheetService();
 
-  List<StageData> _stages = [];
-
   final List<String> shapes = [
     "assets/Circle_basic.svg",
     "assets/Triangle_basic.svg",
@@ -40,25 +39,6 @@ class _MainMenuScreenState extends State<MainMenuScreen>
       vsync: this,
       duration: const Duration(seconds: 8),
     )..repeat(reverse: true);
-
-    _loadDataOnStart();
-  }
-
-  Future<void> _loadDataOnStart() async {
-    setState(() => _isLoading = true);
-    try {
-      final data = await SheetService()
-          .fetchData()
-          .timeout(const Duration(seconds: 8));
-      setState(() {
-        _stages = data;
-      });
-      debugPrint("초기 데이터 불러오기 완료: ${_stages.length}개 스테이지");
-    } catch (e) {
-      debugPrint("초기 데이터 불러오기 실패: $e");
-    } finally {
-      setState(() => _isLoading = false);
-    }
   }
 
   @override
@@ -75,42 +55,35 @@ class _MainMenuScreenState extends State<MainMenuScreen>
       const Alignment(0.25, 0.25),   // hexagon
       const Alignment(0.92, 0.72),   // rectangle
       const Alignment(-0.92, 0.50),  // pentagon
-      // 잘린버전
-      // const Alignment(-0.82, -0.72), // circle
-      // const Alignment(0.92, -0.48),  // triangle
-      // const Alignment(0.32, 0.38),   // hexagon
-      // const Alignment(1.18, 0.78),   // rectangle (잘리게)
-      // const Alignment(-1.15, 0.68),  // pentagon (잘리게)
     ];
     return alignments[index % alignments.length];
   }
 
   Future<void> _refreshData() async {
-    setState(() {
-      _isLoading = true;
-    });
+    setState(() => _isLoading = true);
+    final messenger = ScaffoldMessenger.of(context);
 
     try {
-      final data = await sheetService
-          .fetchData()
+      final allSheetNames = await sheetService.fetchSheetNames().timeout(const Duration(seconds: 8));
+      final stageNames = allSheetNames
+          .where((n) => n.startsWith('Stage') || n.startsWith('Stages'))
+          .toList();
+      cachedStageSheetNames = stageNames.isNotEmpty ? stageNames : allSheetNames;
+      cachedStages = await sheetService
+          .fetchData(preloadedSheetNames: allSheetNames)
           .timeout(const Duration(seconds: 8));
-      setState(() {
-        _stages = data;
-      });
 
-      debugPrint("${data.length}개의 StageData 불러옴!");
-      ScaffoldMessenger.of(context).showSnackBar(
+      debugPrint("${cachedStages.length}개의 StageData 불러옴!");
+      messenger.showSnackBar(
         const SnackBar(content: Text("데이터가 새로고침되었습니다.")),
       );
     } catch (e) {
       debugPrint("데이터 불러오기 실패: $e");
-      ScaffoldMessenger.of(context).showSnackBar(
+      messenger.showSnackBar(
         const SnackBar(content: Text("데이터 불러오기에 실패했습니다.")),
       );
     } finally {
-      setState(() {
-        _isLoading = false;
-      });
+      if (mounted) setState(() => _isLoading = false);
     }
   }
 
@@ -120,8 +93,8 @@ class _MainMenuScreenState extends State<MainMenuScreen>
       backgroundColor: const Color(bgColor),
       body: GestureDetector(
         behavior: HitTestBehavior.opaque, // 빈 영역 터치도 인식
-        onTap: () {
-          context.push('/stages', extra: _stages);
+        onTap: _isLoading ? null : () {
+          context.push('/stages', extra: cachedStages);
         },
         child: Stack(
           alignment: Alignment.center,
@@ -189,7 +162,7 @@ class _MainMenuScreenState extends State<MainMenuScreen>
                 ),
 
                 Transform.translate(
-                  offset: const Offset(0, -2), // 👉 핵심
+                  offset: const Offset(0, -2),
                   child: Text(
                     'Out',
                     textAlign: TextAlign.center,
@@ -238,7 +211,7 @@ class _MainMenuScreenState extends State<MainMenuScreen>
                 const SizedBox(height: 150),
 
                 _isLoading
-                    ? const CircularProgressIndicator() // 로딩 중이면 인디케이터 표시
+                    ? const CircularProgressIndicator()
                     : IconButton(
                   icon: const Icon(Icons.refresh),
                   iconSize: 40,
@@ -247,8 +220,6 @@ class _MainMenuScreenState extends State<MainMenuScreen>
                 ),
 
                 const SizedBox(height: 20),
-
-                // Refresh 버튼 유지
 
                 Text(
                   'Tap to enter',
@@ -269,4 +240,3 @@ class _MainMenuScreenState extends State<MainMenuScreen>
     );
   }
 }
-

--- a/lib/src/routes/MissionSelect.dart
+++ b/lib/src/routes/MissionSelect.dart
@@ -1,4 +1,5 @@
 import 'package:figureout/src/functions/sheet_service.dart';
+import 'package:figureout/main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
@@ -182,12 +183,30 @@ class _MissionSelectScreenState extends State<MissionSelectScreen> {
                               }
 
                               setState(() => selectedIndex = index);
+
+                              // 해당 스테이지 최신 데이터 fetch
+                              List<StageData> freshStages = widget.stages;
+                              if (widget.stageIndex < cachedStageSheetNames.length) {
+                                try {
+                                  final sheetName = cachedStageSheetNames[widget.stageIndex];
+                                  final freshStage = await SheetService()
+                                      .fetchSingleStage(sheetName)
+                                      .timeout(const Duration(seconds: 5));
+                                  if (freshStage != null) {
+                                    freshStages = List.of(widget.stages)..[widget.stageIndex] = freshStage;
+                                    cachedStages = freshStages;
+                                  }
+                                } catch (e) {
+                                  debugPrint('[Sheet] Stage re-fetch failed, using cached: $e');
+                                }
+                              }
+
                               await Future.delayed(const Duration(milliseconds: 300));
                               if (!mounted) return;
                               context.push(
                                 '/game',
                                 extra: GameRouteArgs(
-                                  stages: widget.stages,
+                                  stages: freshStages,
                                   stageIndex: widget.stageIndex,
                                   missionIndex: missionNo - 1,
                                 ),


### PR DESCRIPTION
## Summary

- Re-fetch only the selected stage's sheet (~0.5s, 1 API call) on mission tap so the game always starts with fresh data
- Cache all stage data globally at app startup for fast stage/mission list display
- Silently fall back to cached data if re-fetch fails

## Changes

- **`main.dart`**: Fetch all stage data at startup (like translations) and store in `cachedStages` / `cachedStageSheetNames` globals
- **`sheet_service.dart`**: Add `fetchSingleStage(sheetName)` method; add `preloadedSheetNames` param to `fetchData()` to avoid a redundant API call
- **`MainMenu.dart`**: Remove RouteAware / re-fetch complexity; read directly from global cache
- **`MissionSelect.dart`**: On mission tap, re-fetch only the selected stage's sheet before navigating to the game

## Flow

```
App launch   → fetch all stages → store in cachedStages
Mission tap  → re-fetch selected stage sheet only (~0.5s)
Game entry   → always uses fresh data
```

## Test plan

- [ ] Stage and mission list displays correctly after app launch
- [ ] Modifying Google Sheets data and tapping a mission reflects the updated data in-game
- [ ] With no network on mission tap, game falls back to cached data without crashing