### PR TITLE
fix: reverse slide direction when navigating back from stage select to main

### DIFF
--- a/lib/src/routes/StageSelect.dart
+++ b/lib/src/routes/StageSelect.dart
@@ -188,7 +188,7 @@ class _StageSelectScreenState extends State<StageSelectScreen> {
                   Align(
                     alignment: Alignment.centerLeft,
                     child: GestureDetector(
-                      onTap: () => context.push('/'),
+                      onTap: () => context.pop(),
                       child: SvgPicture.asset(
                         "assets/menu/common/Arrow_prev.svg",
                         width: arrowSize,


### PR DESCRIPTION
## Summary
- Changed `context.push('/')` to `context.pop()` in StageSelect back button handler
- Stage select screen now slides right-to-left (back direction) when returning to main menu, consistent with the existing back navigation pattern applied in PR #161

## Test plan
- [ ] Tap the back arrow on the Stage Select screen and verify the screen slides from left to right back to the main menu