### PR TITLE
feat: navigate to next stage on last mission clear + end-of-game placeholder

### DIFF
--- a/lib/src/routes/AftermathScreen.dart
+++ b/lib/src/routes/AftermathScreen.dart
@@ -9,6 +9,7 @@ class AftermathOverlayWidget extends StatelessWidget {
   final int starCount;
   final int stgIndex;
   final int msnIndex;
+  final bool isEndOfGame;
   final VoidCallback onContinue;
   final VoidCallback onRetry;
   final VoidCallback onPlay;
@@ -20,6 +21,7 @@ class AftermathOverlayWidget extends StatelessWidget {
     required this.starCount,
     required this.stgIndex,
     required this.msnIndex,
+    required this.isEndOfGame,
     required this.onContinue,
     required this.onRetry,
     required this.onPlay,
@@ -188,20 +190,34 @@ class AftermathOverlayWidget extends StatelessWidget {
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: result == StageResult.success
-                      ? [
-                          Image.asset('assets/Next_button_icon.png', width: pillH * 0.6, height: pillH * 0.6),
-                          SizedBox(width: pillW * 0.04),
-                          Text(
-                            'Next',
-                            style: TextStyle(
-                              fontFamily: appFontFamily,
-                              fontSize: pillH * 0.55,
-                              fontWeight: FontWeight.bold,
-                              color: Color(0xFFE4E0D3),
-                              decoration: TextDecoration.none,
-                            ),
-                          ),
-                        ]
+                      ? (isEndOfGame
+                          // TODO: 에셋 추가 시 이 블록을 Finish/Complete 버튼으로 교체
+                          ? [
+                              Text(
+                                'Finish',
+                                style: TextStyle(
+                                  fontFamily: appFontFamily,
+                                  fontSize: pillH * 0.55,
+                                  fontWeight: FontWeight.bold,
+                                  color: Color(0xFFE4E0D3),
+                                  decoration: TextDecoration.none,
+                                ),
+                              ),
+                            ]
+                          : [
+                              Image.asset('assets/Next_button_icon.png', width: pillH * 0.6, height: pillH * 0.6),
+                              SizedBox(width: pillW * 0.04),
+                              Text(
+                                'Next',
+                                style: TextStyle(
+                                  fontFamily: appFontFamily,
+                                  fontSize: pillH * 0.55,
+                                  fontWeight: FontWeight.bold,
+                                  color: Color(0xFFE4E0D3),
+                                  decoration: TextDecoration.none,
+                                ),
+                              ),
+                            ])
                       : [
                           Container(
                             padding: EdgeInsets.symmetric(horizontal: pillW * 0.04, vertical: pillH * 0.12),

--- a/lib/src/routes/MainGameScreen.dart
+++ b/lib/src/routes/MainGameScreen.dart
@@ -96,6 +96,7 @@ class _MainGameScreenState extends State<MainGameScreen> {
                     starCount: g.currentAftermathStars,
                     stgIndex: g.currentAftermathStgIndex,
                     msnIndex: g.currentAftermathMsnIndex,
+                    isEndOfGame: g.currentAftermathIsEndOfGame,
                     onContinue: g.handleAftermathContinue,
                     onRetry: g.handleAftermathRetry,
                     onPlay: g.handleAftermathPlay,

--- a/lib/src/routes/OneSecondGame.dart
+++ b/lib/src/routes/OneSecondGame.dart
@@ -68,11 +68,13 @@ class OneSecondGame extends FlameGame
   int _currentAftermathStars = 0;
   int _currentAftermathStgIndex = 0;
   int _currentAftermathMsnIndex = 0;
+  bool _currentAftermathIsEndOfGame = false;
 
   StageResult? get currentAftermathResult => _currentAftermathResult;
   int get currentAftermathStars => _currentAftermathStars;
   int get currentAftermathStgIndex => _currentAftermathStgIndex;
   int get currentAftermathMsnIndex => _currentAftermathMsnIndex;
+  bool get currentAftermathIsEndOfGame => _currentAftermathIsEndOfGame;
 
   //stage data
   late StageData initialStage;
@@ -1660,6 +1662,13 @@ class OneSecondGame extends FlameGame
       await Future.delayed(const Duration(milliseconds: 100));
     }
 
+    // 다음 미션/스테이지 존재 여부 계산
+    final isLastMission = _selectedMissionIndex >= maxMissionIndex;
+    final nextStageIndex = _selectedStageIndex + 1;
+    final hasNextStage = nextStageIndex < _allStages.length;
+    final nextStageHasMissions = hasNextStage && _allStages[nextStageIndex].missions.isNotEmpty;
+    _currentAftermathIsEndOfGame = isLastMission && !nextStageHasMissions;
+
     _currentAftermathResult = result;
     _currentAftermathStars = starCount;
     _currentAftermathStgIndex = stgIndex;
@@ -2553,23 +2562,31 @@ bool _isStraightLine(List<Vector2> path) {
   void handleAftermathPlay() {
     _removeAftermathOverlay();
 
-    final isLastStage = _selectedStageIndex >= maxStageIndex - 1;
     final isLastMission = _selectedMissionIndex >= maxMissionIndex;
 
-    if (isLastStage && isLastMission) {
-      rootNavigatorKey.currentContext!.go('/stages', extra: stages);
+    if (!isLastMission) {
+      // 같은 스테이지의 다음 미션
+      _selectedMissionIndex += 1;
+      runStageWithAftermath(_selectedStageIndex, _selectedMissionIndex);
       return;
     }
 
-    if (_selectedStageIndex < maxStageIndex) {
-      if (_selectedMissionIndex < maxMissionIndex) {
-        _selectedMissionIndex = _selectedMissionIndex + 1;
-      } else {
-        _selectedStageIndex = 0;
-        _selectedMissionIndex = 0;
-      }
+    // 마지막 미션 — 다음 스테이지로 이동
+    final nextStageIndex = _selectedStageIndex + 1;
+    final hasNextStage = nextStageIndex < _allStages.length;
+    final nextStageHasMissions = hasNextStage && _allStages[nextStageIndex].missions.isNotEmpty;
+
+    if (nextStageHasMissions) {
+      _selectedStageIndex = nextStageIndex;
+      _selectedMissionIndex = 1;
+      maxMissionIndex = _allStages[_selectedStageIndex].missions.length;
       runStageWithAftermath(_selectedStageIndex, _selectedMissionIndex);
+      return;
     }
+
+    // 다음 스테이지가 없거나 미션이 없음 → 스테이지 선택창으로
+    // TODO: 추후 Finish/Complete 에셋 추가 시 이 화면 전환 전에 별도 연출 추가
+    rootNavigatorKey.currentContext!.go('/stages', extra: stages);
   }
 
   void handleAftermathMenu() {

--- a/lib/src/routes/StageSelect.dart
+++ b/lib/src/routes/StageSelect.dart
@@ -188,7 +188,7 @@ class _StageSelectScreenState extends State<StageSelectScreen> {
                   Align(
                     alignment: Alignment.centerLeft,
                     child: GestureDetector(
-                      onTap: () => context.pop(),
+                      onTap: () => context.canPop() ? context.pop() : context.go('/'),
                       child: SvgPicture.asset(
                         "assets/menu/common/Arrow_prev.svg",
                         width: arrowSize,


### PR DESCRIPTION
## Summary

This PR fixes the blank screen that appeared when tapping **Next** after clearing the last mission of a stage, and defines the full post-mission navigation flow.

---

## Problem

When the last mission of a stage was cleared and the player tapped **Next**, the game called `runStageWithAftermath` with mission index `0`, which does not exist in the missions map (missions are 1-indexed). This resulted in a blank screen with no way to proceed.

Additionally, navigating to `/stages` via `go()` (which replaces the navigation stack) caused a `GoError: There is nothing to pop` when tapping the back button on the stage select screen.

---

## Flow After This Change

```
Mission cleared → Aftermath screen appears → Player taps Next
│
├── Has more missions in the current stage?
│   └── YES → Load next mission in the same stage (existing behavior)
│
├── NO — Is this the last mission of the stage?
│   │
│   ├── Next stage exists and has missions?
│   │   └── YES → Navigate to next stage, mission 1
│   │
│   └── No next stage (or next stage has no missions)?
│       └── Show "Finish" placeholder button
│           └── Player taps Finish → go('/stages') → Stage select screen
│               └── Back button → go('/') → Main menu
```

---

## Changes

### `OneSecondGame.dart`
- Rewrote `handleAftermathPlay()` with the three-branch logic above
- Added `_currentAftermathIsEndOfGame` field and getter
- In `showAftermathScreen()`, computes `isEndOfGame` based on whether a valid next stage exists

### `MainGameScreen.dart`
- Passes `isEndOfGame` to `AftermathOverlayWidget`

### `AftermathScreen.dart`
- Added `isEndOfGame` parameter
- When `result == success && isEndOfGame`: renders a **"Finish"** placeholder pill button instead of the normal Next button
- Tapping it triggers `onPlay`, which navigates to the stage select screen

### `StageSelect.dart`
- Back button now uses `canPop() ? pop() : go('/')` to handle both normal push-navigation and direct `go()` entry from the game

---

## Design Asset — To Be Requested Later

The **"Finish" button is currently a text-only placeholder** (`// TODO: Replace with Finish/Complete asset when available`).

We'll need to request a Figma asset from the design team at some point — a pill button matching the style of the existing Next button, labeled either **"Complete"** or **"Finish"**.

---

## Test Plan

- [ ] Clear a non-last mission → Next loads the next mission in the same stage
- [ ] Clear the last mission of a non-last stage → Next loads mission 1 of the next stage
- [ ] Clear the last mission of the last stage → Aftermath shows "Finish" placeholder button
- [ ] Tap "Finish" → Returns to stage select screen
- [ ] Tap back on stage select (after arriving from game) → Returns to main menu without error