### PR TITLE
fix: stop BlinkingBehaviorComponent from reviving shapes killed by attack timer

### DIFF
--- a/lib/src/functions/BlinkingBehavior.dart
+++ b/lib/src/functions/BlinkingBehavior.dart
@@ -77,6 +77,14 @@ class BlinkingBehaviorComponent extends Component with HasGameReference {
       removeFromParent();
       return;
     }
+
+    // BBC가 visible이라고 판단 중인데 도형이 실제로 없으면
+    // 공격 타이머 등 외부 원인으로 제거된 것이므로 BBC도 함께 제거
+    if (_visible && !shape.isMounted) {
+      removeFromParent();
+      return;
+    }
+
     _timer += dt;
 
     if (_visible && !_fadeStarted && _timer >= _fadeStartTime) {


### PR DESCRIPTION
## Summary

- Shapes with D/DR behavior were being revived after their attack timer expired
- When the attack timer fired, the shape called `removeFromParent()` but the BlinkingBehaviorComponent (BBC) kept running and re-added the shape after the invisible phase elapsed
- Added a guard in `BlinkingBehaviorComponent.update()` that kills the BBC immediately if it thinks the shape is visible but the shape is no longer mounted

## Test Plan

- [ ] Spawn a shape with an attack timer and a D or DR command
- [ ] Let the attack timer run out
- [ ] Confirm the shape explodes and does NOT reappear
- [ ] Confirm normal D/DR blink cycle still works for shapes without an attack timer