### PR TITLE
feat: implement triangle slice destruction animation

### DIFF
--- a/lib/src/components/TriangleShape.dart
+++ b/lib/src/components/TriangleShape.dart
@@ -1,5 +1,3 @@
-import 'dart:math' as math;
-
 import 'package:figureout/src/functions/UserRemovable.dart';
 import 'package:figureout/src/functions/blink_alpha_target.dart';
 import 'package:figureout/src/routes/OneSecondGame.dart';
@@ -9,6 +7,7 @@ import 'package:flame/events.dart';
 import 'package:flutter/material.dart';
 
 import '../effect/AttackExplosionEffect.dart';
+import '../effect/EncircleSliceEffect.dart';
 import '../functions/OverlapHighlightable.dart';
 import 'shape_path_utils.dart';
 
@@ -27,42 +26,26 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
 
   double _attackElapsed = 0.0;
   bool _attackDone = false;
-  bool _penaltyFired = false; 
+  bool _penaltyFired = false;
   bool isPaused = false;
 
   double _blinkAlpha = 1.0;
-  double _shapeOpacity = 1.0;
+
+  // 이중 트리거 방지
+  bool _isDisappearing = false;
 
   final Paint _overlapOutlinePaint = Paint()
     ..color = Colors.black
     ..style = PaintingStyle.stroke
     ..strokeWidth = 3.0;
 
-  void setBlinkAlpha(double alpha){
+  void setBlinkAlpha(double alpha) {
     if (_isDisappearing) return;
-
     _blinkAlpha = alpha.clamp(0.0, 1.0);
-
     _hpTextComponent?.textRenderer = TextPaint(
       style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Colors.black.withValues(alpha: _blinkAlpha)),
     );
   }
-
-  // ===== 사라짐 애니메이션 상태 (유저 제거용) =====
-  bool _isDisappearing = false;
-  double _disappearTime = 0.0;
-
-  final double _disappearDuration = 0.8;
-
-  static const double _shrinkEndT = 0.85;
-  static const double _holdEndT = 0.97;
-  static const double _minScale = 0.06;
-
-  late double _startAngle;
-  late Vector2 _startScale;
-
-  double _baseRotationSpeed = 0.0;
-  double _rotDir = 1.0;
 
   late Sprite _sprite;
   late Path _outlinePath;
@@ -75,7 +58,7 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
     ..strokeJoin = StrokeJoin.round
     ..strokeCap = StrokeCap.round
     ..color = const Color(0xFFF2AC32);
-  // 0xFF345983
+
   final Color baseColor = const Color(0xFFAE7F2D);
   final Color dangerColor = const Color(0xFFEE0505);
 
@@ -107,7 +90,6 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
     _wobblePath = ShapePathUtils.wobble(_outlinePath, amplitude: size.x * 0.009);
 
     if (!isDark && energy >= 1) {
-      // centroid of SVG triangle (top:3.5, bot:78.5 on 86h grid) = y * (3.5+78.5+78.5)/(86*3)
       _hpTextComponent = TextComponent(
         text: energy.toString(),
         anchor: Anchor.center,
@@ -122,12 +104,11 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
   }
 
   // ==========================================================
-  // 유저 제거 트리거
+  // 유저 제거 트리거 — EncircleSliceEffect 스폰 후 즉시 제거
   // ==========================================================
   void triggerDisappear() {
     if (_isDisappearing) return;
 
-    // 에너지가 남아있으면 1 깎고 리턴 (아직 살아있음)
     if (energy > 1) {
       energy--;
       if (energy >= 1) {
@@ -139,9 +120,9 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
       return;
     }
 
+    _isDisappearing = true;
     _hpTextComponent?.removeFromParent();
     _hpTextComponent = null;
-    _isDisappearing = true;
     wasRemovedByUser = true;
 
     final parentGame = findGame();
@@ -149,12 +130,23 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
       parentGame.blinkingMap.remove(this);
     }
 
-    _disappearTime = 0.0;
-    _startScale = scale.clone();
-    _startAngle = angle;
+    // 삼각형 centroid = anchor(0.5, 0.62) = position(world)
+    const svgW = 96.0, svgH = 86.0;
+    final pivotX = size.x * (48.0 + 2.1 + 93.9) / (3 * svgW);  // size.x / 2
+    final pivotY = size.y * (3.5 + 78.5 + 78.5) / (3 * svgH);  // size.y * 0.622
 
-    _rotDir = math.Random().nextBool() ? 1.0 : -1.0;
-    _baseRotationSpeed = math.pi * 2.2;
+    parent?.add(
+      EncircleSliceEffect(
+        basePath: _buildExplosionTrianglePath(),
+        color: const Color(0xFFF2AC32),
+        position: Vector2(position.x - 2.0, position.y),
+        size: size.clone(),
+        pivot: Offset(pivotX, pivotY),
+        initialAngle: angle,
+      ),
+    );
+
+    removeFromParent();
   }
 
   @override
@@ -162,42 +154,7 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
     super.update(dt);
     if (isPaused) return;
 
-    // ======================================================
-    // 유저 제거 애니메이션
-    // ======================================================
-    if (_isDisappearing) {
-      _disappearTime += dt;
-      final t = (_disappearTime / _disappearDuration).clamp(0.0, 1.0);
-
-      final accel = 1.0 + (t * t) * 2.2;
-      angle += (_baseRotationSpeed * accel * _rotDir) * dt;
-
-      if (t <= _shrinkEndT) {
-        final localT = (t / _shrinkEndT).clamp(0.0, 1.0);
-        final eased = Curves.easeInCubic.transform(localT);
-        final s = 1.0 - (1.0 - _minScale) * eased;
-        scale = _startScale * s;
-        _shapeOpacity = 1.0;
-      } else if (t <= _holdEndT) {
-        scale = _startScale * _minScale;
-        _shapeOpacity = 1.0;
-      } else {
-        scale = _startScale * _minScale;
-        final localT =
-            ((t - _holdEndT) / (1.0 - _holdEndT)).clamp(0.0, 1.0);
-        final eased = Curves.easeOutCubic.transform(localT);
-        _shapeOpacity = 1.0 - eased;
-      }
-
-      if (t >= 1.0) {
-        removeFromParent();
-      }
-      return;
-    }
-
-    // ======================================================
-    // 공격 타이머 → 즉시 자폭
-    // ======================================================
+    // 공격 타이머 → 즉시 자폭 (AttackExplosionEffect)
     if ((attackTime ?? 0) <= 0) return;
 
     _attackElapsed += dt;
@@ -207,10 +164,9 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
 
       if (!_penaltyFired) {
         _penaltyFired = true;
-        onExplode?.call(); // 시간 패널티
+        onExplode?.call();
       }
 
-      // 타이머 자폭은 유저 제거 아님
       wasRemovedByUser = false;
 
       const svgW = 96.0, svgH = 86.0;
@@ -232,9 +188,7 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
       );
 
       removeFromParent();
-      return;
     }
-
   }
 
   bool get _attackTimeHalfLeft {
@@ -257,8 +211,9 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
   @override
   static const double _borderHalo = 0.05;
 
+  @override
   void render(Canvas canvas) {
-    final alpha = (_blinkAlpha * _shapeOpacity).clamp(0.0, 1.0);
+    final alpha = _blinkAlpha.clamp(0.0, 1.0);
 
     _sprite.render(
       canvas,
@@ -303,9 +258,7 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
 
     super.render(canvas);
 
-    if ((attackTime ?? 0) > 0 && !_attackDone
-        // && !_isDisappearing
-    ) {
+    if ((attackTime ?? 0) > 0 && !_attackDone) {
       final ratio =
           ((attackTime! - _attackElapsed) / attackTime!).clamp(0.0, 1.0);
       final drawLen = _outlineLength * ratio;
@@ -319,8 +272,6 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
 
   Path _buildTrianglePath(Size s) {
     final inset = -3.0;
-    // SVG viewBox 96×86 기준 삼각형 꼭짓점
-    // top: (48, 3.5), bottomLeft: (2.1, 78.5), bottomRight: (93.9, 78.5)
     const double svgW = 96, svgH = 86;
 
     final topX   = s.width  * (48.0  / svgW);
@@ -336,7 +287,6 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
       ..close();
   }
 
-  // ===== 기존 삼각형 판정 로직 유지 =====
   List<Vector2> getTriangleVertices() {
     final c = absoluteCenter;
     final hw = size.x / 2;
@@ -380,7 +330,7 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
       ..lineTo(w * (93.9  / svgW), h * (78.5 / svgH))
       ..close();
   }
-  
+
   @override
   void onTapDown(TapDownEvent event) {
     event.continuePropagation = false;
@@ -390,4 +340,3 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
     }
   }
 }
-

--- a/lib/src/effect/EncircleSliceEffect.dart
+++ b/lib/src/effect/EncircleSliceEffect.dart
@@ -1,0 +1,140 @@
+import 'dart:math';
+import 'dart:ui';
+import 'package:flame/components.dart';
+import 'package:flutter/material.dart' show Curves;
+
+class EncircleSliceEffect extends PositionComponent {
+  final Path basePath;
+  final Color color;
+
+  static const double _totalDuration = 0.70; // ~1.5x longer so fragments linger
+  static const double _t1 = 0.67; // Phase 1 ends at ~67% (~313ms)
+
+  // Pill flight directions (180° flip from previous):
+  //   -pi/2   → UP          (fragment 1, vertical pill)
+  //    pi/6   → lower-right (fragment 3)
+  //   5*pi/6  → lower-left  (fragment 2)
+  static const List<double> _pillDirs = [-pi / 2, pi / 6, 5 * pi / 6];
+
+  double _elapsed = 0.0;
+  final double _initialAngle;
+  late final double _cx, _cy, _shapeR;
+
+  EncircleSliceEffect({
+    required this.basePath,
+    required this.color,
+    required Vector2 position,
+    required Vector2 size,
+    Offset? pivot,
+    double initialAngle = 0.0,
+  })  : _initialAngle = initialAngle,
+        super(size: size) {
+    if (pivot != null) {
+      _cx = pivot.dx;
+      _cy = pivot.dy;
+    } else {
+      final b = basePath.getBounds();
+      _cx = (b.left + b.right) / 2;
+      _cy = (b.top + b.bottom) / 2;
+    }
+    _shapeR = (size.x + size.y) / 4;
+    this.position = Vector2(position.x - _cx, position.y - _cy);
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    _elapsed += dt;
+    if (_elapsed >= _totalDuration) removeFromParent();
+  }
+
+  @override
+  void render(Canvas canvas) {
+    final t = (_elapsed / _totalDuration).clamp(0.0, 1.0);
+    final paint = Paint()
+      ..style = PaintingStyle.fill
+      ..color = color;
+
+    if (t <= _t1) {
+      // Phase 1: basePath rotates 90° (ease-out) + minimal scale reduction
+      final localT = t / _t1;
+      final progress = Curves.easeOut.transform(localT);
+      final angle = _initialAngle + (pi / 2) * progress;
+      final sc = lerpDouble(1.0, 0.85, progress)!;
+
+      canvas.save();
+      canvas.translate(_cx, _cy);
+      canvas.rotate(angle);
+      canvas.scale(sc, sc);
+      canvas.translate(-_cx, -_cy);
+      canvas.drawPath(basePath, paint);
+      canvas.restore();
+    } else {
+      // Phase 2: 3 short dash fragments fly outward from a tight, clearly-
+      // separated cluster (reference: Triangle 5→8). Start as short dots with
+      // visible gaps between them; length AND spread grow together to a peak;
+      // past the peak, only the length shrinks back to its starting size
+      // (spread keeps drifting outward, never retreats) and only then fades.
+      final localT = (t - _t1) / (1.0 - _t1);
+
+      const double growEnd = 0.55; // growth phase ends here, then shrink begins
+
+      // Fixed thickness (short axis) — kept thin so the fragment always reads
+      // as a dash, never a fat blob.
+      final pillHalfH = _shapeR * 0.07;
+      final pillHalfWMax = _shapeR * 0.45;
+
+      // Start/end half-length is derived from pillHalfH (not a magic fraction
+      // of pillHalfWMax) so the fragment always starts as a near-round blob:
+      // width ≈ height * 1.0~1.2, regardless of how pillHalfWMax is tuned.
+      const double startWidthToHeightRatio = 1.1;
+      final double startLen = (pillHalfH * startWidthToHeightRatio) / pillHalfWMax;
+
+      // Half-length factor: startLen → 1.0x (0~growEnd, ease-out),
+      // 1.0x → startLen (growEnd~100%, ease-in: slow start, fast finish).
+      // Baked directly into the RRect geometry (not a canvas transform) so the
+      // corner radius shrinks along with it instead of flooring the min size.
+      final double lengthFactor;
+      if (localT <= growEnd) {
+        final p = Curves.easeOut.transform(localT / growEnd);
+        lengthFactor = lerpDouble(startLen, 1.0, p)!;
+      } else {
+        final p = Curves.easeIn.transform((localT - growEnd) / (1.0 - growEnd));
+        lengthFactor = lerpDouble(1.0, startLen, p)!;
+      }
+      final pillHalfW = pillHalfWMax * lengthFactor;
+
+      // Position: spread grows monotonically for the whole phase (never
+      // retreats back toward center, even while the length shrinks again).
+      // Min spread is well beyond the fragment's own size so the 3 fragments
+      // start clearly separated instead of overlapping at the center.
+      final spreadP = Curves.easeOut.transform(localT);
+      final spread = _shapeR * lerpDouble(0.44, 1.07, spreadP)!;
+
+      // Opacity: holds full while growing/shrinking, only fades right at the
+      // very end once the length is back down near its starting size.
+      final double opacity;
+      if (localT <= 0.8) {
+        opacity = 1.0;
+      } else {
+        opacity = 1.0 - Curves.easeIn.transform((localT - 0.8) / 0.2);
+      }
+
+      // ignore: deprecated_member_use
+      paint.color = color.withOpacity(opacity);
+
+      final pillRRect = RRect.fromRectAndRadius(
+        Rect.fromCenter(center: Offset.zero, width: pillHalfW * 2, height: pillHalfH * 2),
+        Radius.circular(min(pillHalfH, pillHalfW)),
+      );
+
+      for (final dir in _pillDirs) {
+        canvas.save();
+        canvas.translate(_cx + cos(dir) * spread, _cy + sin(dir) * spread);
+        canvas.rotate(dir);
+        canvas.drawRRect(pillRRect, paint);
+        canvas.restore();
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Add two-phase destruction animation on slice trigger
- Phase 1: shape rotates 90° with scale maintained, ease-out curve
- Phase 2: three pill-shaped particles spread in inverted-Y direction
- Particles start as small blobs, grow to max length, shrink and fade out