### PR TITLE
feat: navigate to stage select after last mission

### DIFF
--- a/lib/src/routes/AftermathScreen.dart
+++ b/lib/src/routes/AftermathScreen.dart
@@ -9,7 +9,6 @@ class AftermathOverlayWidget extends StatelessWidget {
   final int starCount;
   final int stgIndex;
   final int msnIndex;
-  final bool isEndOfGame;
   final VoidCallback onContinue;
   final VoidCallback onRetry;
   final VoidCallback onPlay;
@@ -21,7 +20,6 @@ class AftermathOverlayWidget extends StatelessWidget {
     required this.starCount,
     required this.stgIndex,
     required this.msnIndex,
-    required this.isEndOfGame,
     required this.onContinue,
     required this.onRetry,
     required this.onPlay,
@@ -190,34 +188,20 @@ class AftermathOverlayWidget extends StatelessWidget {
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: result == StageResult.success
-                      ? (isEndOfGame
-                          // TODO: 에셋 추가 시 이 블록을 Finish/Complete 버튼으로 교체
-                          ? [
-                              Text(
-                                'Finish',
-                                style: TextStyle(
-                                  fontFamily: appFontFamily,
-                                  fontSize: pillH * 0.55,
-                                  fontWeight: FontWeight.bold,
-                                  color: Color(0xFFE4E0D3),
-                                  decoration: TextDecoration.none,
-                                ),
-                              ),
-                            ]
-                          : [
-                              Image.asset('assets/Next_button_icon.png', width: pillH * 0.6, height: pillH * 0.6),
-                              SizedBox(width: pillW * 0.04),
-                              Text(
-                                'Next',
-                                style: TextStyle(
-                                  fontFamily: appFontFamily,
-                                  fontSize: pillH * 0.55,
-                                  fontWeight: FontWeight.bold,
-                                  color: Color(0xFFE4E0D3),
-                                  decoration: TextDecoration.none,
-                                ),
-                              ),
-                            ])
+                      ? [
+                          Image.asset('assets/Next_button_icon.png', width: pillH * 0.6, height: pillH * 0.6),
+                          SizedBox(width: pillW * 0.04),
+                          Text(
+                            'Next',
+                            style: TextStyle(
+                              fontFamily: appFontFamily,
+                              fontSize: pillH * 0.55,
+                              fontWeight: FontWeight.bold,
+                              color: Color(0xFFE4E0D3),
+                              decoration: TextDecoration.none,
+                            ),
+                          ),
+                        ]
                       : [
                           Container(
                             padding: EdgeInsets.symmetric(horizontal: pillW * 0.04, vertical: pillH * 0.12),

--- a/lib/src/routes/MainGameScreen.dart
+++ b/lib/src/routes/MainGameScreen.dart
@@ -96,7 +96,6 @@ class _MainGameScreenState extends State<MainGameScreen> {
                     starCount: g.currentAftermathStars,
                     stgIndex: g.currentAftermathStgIndex,
                     msnIndex: g.currentAftermathMsnIndex,
-                    isEndOfGame: g.currentAftermathIsEndOfGame,
                     onContinue: g.handleAftermathContinue,
                     onRetry: g.handleAftermathRetry,
                     onPlay: g.handleAftermathPlay,

--- a/lib/src/routes/OneSecondGame.dart
+++ b/lib/src/routes/OneSecondGame.dart
@@ -2616,19 +2616,30 @@ bool _isStraightLine(List<Vector2> path) {
   void handleAftermathPlay() {
     _removeAftermathOverlay();
 
-    final isLastMission = _selectedMissionIndex >= maxMissionIndex;
+    // 마지막 미션 여부는 "미션 개수"가 아니라 "실제 존재하는 최대 미션 번호"로 판단한다.
+    // (미션 키가 비연속적이거나 보스 미션 등으로 개수 != 최대 번호일 수 있음)
+    final missionKeys = _allStages[_selectedStageIndex].missions.keys.toList()
+      ..sort();
+    final maxMissionNo =
+        missionKeys.isNotEmpty ? missionKeys.last : _selectedMissionIndex;
+    final isLastMission = _selectedMissionIndex >= maxMissionNo;
 
     if (!isLastMission) {
-      // 같은 스테이지의 다음 미션
-      _selectedMissionIndex += 1;
+      // 같은 스테이지의 다음(실제 존재하는) 미션으로 이동
+      final nextMissionNo = missionKeys.firstWhere(
+        (k) => k > _selectedMissionIndex,
+        orElse: () => _selectedMissionIndex + 1,
+      );
+      _selectedMissionIndex = nextMissionNo;
       runStageWithAftermath(_selectedStageIndex, _selectedMissionIndex);
       return;
     }
 
     // 마지막 미션 — 스테이지 선택 화면으로 이동
+    // 마지막 스테이지 여부는 인덱스로만 판단한다. (다음 스테이지에 미션 데이터가
+    // 아직 없더라도, 실제 마지막 스테이지가 아니면 다음 스테이지를 띄워준다.)
     final nextStageIndex = _selectedStageIndex + 1;
-    final hasNextStage = nextStageIndex < _allStages.length &&
-        _allStages[nextStageIndex].missions.isNotEmpty;
+    final hasNextStage = nextStageIndex < _allStages.length;
 
     // 다음 스테이지가 있으면 다음 스테이지를, 마지막 스테이지였다면 현재(마지막) 스테이지를 띄워준다.
     final targetStageIndex = hasNextStage ? nextStageIndex : _selectedStageIndex;

--- a/lib/src/routes/OneSecondGame.dart
+++ b/lib/src/routes/OneSecondGame.dart
@@ -70,13 +70,11 @@ class OneSecondGame extends FlameGame
   int _currentAftermathStars = 0;
   int _currentAftermathStgIndex = 0;
   int _currentAftermathMsnIndex = 0;
-  bool _currentAftermathIsEndOfGame = false;
 
   StageResult? get currentAftermathResult => _currentAftermathResult;
   int get currentAftermathStars => _currentAftermathStars;
   int get currentAftermathStgIndex => _currentAftermathStgIndex;
   int get currentAftermathMsnIndex => _currentAftermathMsnIndex;
-  bool get currentAftermathIsEndOfGame => _currentAftermathIsEndOfGame;
 
   //stage data
   late StageData initialStage;
@@ -1689,13 +1687,6 @@ class OneSecondGame extends FlameGame
       await Future.delayed(const Duration(milliseconds: 100));
     }
 
-    // 다음 미션/스테이지 존재 여부 계산
-    final isLastMission = _selectedMissionIndex >= maxMissionIndex;
-    final nextStageIndex = _selectedStageIndex + 1;
-    final hasNextStage = nextStageIndex < _allStages.length;
-    final nextStageHasMissions = hasNextStage && _allStages[nextStageIndex].missions.isNotEmpty;
-    _currentAftermathIsEndOfGame = isLastMission && !nextStageHasMissions;
-
     _currentAftermathResult = result;
     _currentAftermathStars = starCount;
     _currentAftermathStgIndex = stgIndex;
@@ -2634,22 +2625,18 @@ bool _isStraightLine(List<Vector2> path) {
       return;
     }
 
-    // 마지막 미션 — 다음 스테이지로 이동
+    // 마지막 미션 — 스테이지 선택 화면으로 이동
     final nextStageIndex = _selectedStageIndex + 1;
-    final hasNextStage = nextStageIndex < _allStages.length;
-    final nextStageHasMissions = hasNextStage && _allStages[nextStageIndex].missions.isNotEmpty;
+    final hasNextStage = nextStageIndex < _allStages.length &&
+        _allStages[nextStageIndex].missions.isNotEmpty;
 
-    if (nextStageHasMissions) {
-      _selectedStageIndex = nextStageIndex;
-      _selectedMissionIndex = 1;
-      maxMissionIndex = _allStages[_selectedStageIndex].missions.length;
-      runStageWithAftermath(_selectedStageIndex, _selectedMissionIndex);
-      return;
-    }
+    // 다음 스테이지가 있으면 다음 스테이지를, 마지막 스테이지였다면 현재(마지막) 스테이지를 띄워준다.
+    final targetStageIndex = hasNextStage ? nextStageIndex : _selectedStageIndex;
 
-    // 다음 스테이지가 없거나 미션이 없음 → 스테이지 선택창으로
-    // TODO: 추후 Finish/Complete 에셋 추가 시 이 화면 전환 전에 별도 연출 추가
-    rootNavigatorKey.currentContext!.go('/stages', extra: stages);
+    rootNavigatorKey.currentContext!.go(
+      '/stages',
+      extra: StageRouteArgs(stages: stages, initialStageIndex: targetStageIndex),
+    );
   }
 
   void handleAftermathMenu() {

--- a/lib/src/routes/StageSelect.dart
+++ b/lib/src/routes/StageSelect.dart
@@ -46,6 +46,22 @@ class _StageSelectScreenState extends State<StageSelectScreen> {
   }
 
   @override
+  void didUpdateWidget(covariant StageSelectScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // go('/stages') 재진입 시 State가 재사용되면 initState가 다시 호출되지 않으므로,
+    // initialStageIndex가 바뀌면 해당 스테이지로 강제 이동시킨다.
+    if (widget.initialStageIndex != oldWidget.initialStageIndex &&
+        widget.initialStageIndex != _currentIndex) {
+      _currentIndex = widget.initialStageIndex;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (_pageController.hasClients) {
+          _pageController.jumpToPage(widget.initialStageIndex);
+        }
+      });
+    }
+  }
+
+  @override
   void dispose() {
     _pageController.dispose();
     super.dispose();


### PR DESCRIPTION
## Summary
- After clearing the last mission of a stage, the game no longer auto-advances into the next stage's first mission. Instead it returns to the stage select screen with the appropriate stage pre-selected, letting the player decide whether to enter.
  - If a next stage exists, the stage select opens with the next stage focused.
  - If it was the final stage, the stage select opens with that last stage focused.
- Removed the `isEndOfGame` "Finish" button variant. The success button now always shows "Next".
- Last-mission detection now uses the maximum mission number (not the mission count), and the stage select screen refreshes its focused stage when re-entered.

## Changes
- `OneSecondGame.dart`: `handleAftermathPlay` routes to `/stages` via `StageRouteArgs(initialStageIndex: ...)` on the last mission; removed `isEndOfGame` state/getter; last-mission check uses max mission key and advances to the next existing mission key.
- `AftermathScreen.dart`: dropped `isEndOfGame` field; success button always renders the "Next" icon + label.
- `MainGameScreen.dart`: removed the `isEndOfGame` argument wiring.
- `StageSelect.dart`: added `didUpdateWidget` to jump to the new `initialStageIndex` when the screen is reused on re-entry.

## Test plan
- [ ] Clear the last mission of a non-final stage → returns to stage select with the next stage focused.
- [ ] Clear the last mission of the final stage → returns to stage select with the last stage focused.
- [ ] Clear a non-last mission → still advances to the next mission as before.
- [ ] Success result button always reads "Next".