### PR TITLE
feat: control shape z-order via Top_/Bottom_ position prefix

### DIFF
--- a/lib/src/components/CircleShape.dart
+++ b/lib/src/components/CircleShape.dart
@@ -87,7 +87,7 @@ class CircleShape extends PositionComponent
 
   @override
   Future<void> onLoad() async {
-    priority = 100 + (1000 - size.x).toInt();
+    // z-order(priority)는 스폰 시 생성 순서 기반으로 설정된다. (크기 무관)
     await super.onLoad();
 
     if (order != null) {

--- a/lib/src/components/HexagonShape.dart
+++ b/lib/src/components/HexagonShape.dart
@@ -107,9 +107,7 @@ class HexagonShape extends PositionComponent
 
   @override
   Future<void> onLoad() async {
-
-    priority = 100 + (1000 - size.x).toInt();
-
+    // z-order(priority)는 스폰 시 생성 순서 기반으로 설정된다. (크기 무관)
     await super.onLoad();
 
     _sprite = await Sprite.load('shapes/Hexagon_3x.png', images: _images);

--- a/lib/src/components/PentagonShape.dart
+++ b/lib/src/components/PentagonShape.dart
@@ -140,9 +140,7 @@ class PentagonShape extends PositionComponent
 
   @override
   Future<void> onLoad() async {
-
-    priority = 100 + (1000 - size.x).toInt();
-
+    // z-order(priority)는 스폰 시 생성 순서 기반으로 설정된다. (크기 무관)
     await super.onLoad();
 
     _center = _visualPentagonCenter;

--- a/lib/src/components/PreparedEnemy.dart
+++ b/lib/src/components/PreparedEnemy.dart
@@ -1,5 +1,6 @@
 import 'package:flame/components.dart';
 import '../behaviors/shapeBehavior.dart';
+import '../config.dart';
 
 class PreparedEnemy {
   final String shapeType;
@@ -13,6 +14,7 @@ class PreparedEnemy {
   final double? attackDamage;
   final ShapeBehavior? behavior;
   final double angle;
+  final ShapeZOrder zOrder;
 
   const PreparedEnemy({
     required this.shapeType,
@@ -25,6 +27,7 @@ class PreparedEnemy {
     required this.behavior,
     required this.customSize,
     this.angle = 0.0,
+    this.zOrder = ShapeZOrder.normal,
   });
 
   @override

--- a/lib/src/components/RectangleShape.dart
+++ b/lib/src/components/RectangleShape.dart
@@ -122,7 +122,7 @@ class RectangleShape extends PositionComponent
 
   @override
   Future<void> onLoad() async {
-    priority = 100 + (1000 - size.x).toInt();
+    // z-order(priority)는 스폰 시 생성 순서 기반으로 설정된다. (크기 무관)
     await super.onLoad();
 
     if (order != null) {

--- a/lib/src/components/TriangleShape.dart
+++ b/lib/src/components/TriangleShape.dart
@@ -80,7 +80,7 @@ class TriangleShape extends PositionComponent with TapCallbacks, UserRemovable, 
 
   @override
   Future<void> onLoad() async {
-    priority = 100 + (1000 - size.x).toInt();
+    // z-order(priority)는 스폰 시 생성 순서 기반으로 설정된다. (크기 무관)
     await super.onLoad();
 
     _sprite = await Sprite.load('shapes/Triangle_3x.png', images: _images);

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -34,6 +34,10 @@ const bgColor = 0xFFF2EFE6;
 enum shapes { Circle, Rectangle, Pentagon, Triangle, Hexagon }
 enum StageResult { success, fail, cancelled }
 
+// 도형 겹침(z-order) 힌트. 시트 G열 위치값 접두사(Top_/Bottom_)로 지정한다.
+// top: 항상 맨 위, bottom: 항상 맨 아래, normal: 생성(시트) 순서대로.
+enum ShapeZOrder { top, normal, bottom }
+
 enum URDField {
   shape, size, order, energy,
   positionX, positionY,

--- a/lib/src/functions/sheet_service.dart
+++ b/lib/src/functions/sheet_service.dart
@@ -183,7 +183,9 @@ class SheetService {
       final movement = _safeGet(cells, shapeColumn + 2);
       final resolvedMovement = resolveMovement(movement, ctx);
 
-      final position = _safeGet(cells, shapeColumn + 3);
+      final rawPosition = _safeGet(cells, shapeColumn + 3);
+      final zOrder = _parseZOrderPrefix(rawPosition);
+      final position = _stripZOrderPrefix(rawPosition);
 
       final resolvedAttackRaw = resolveAttack(attackRaw, ctx);
       final resolvedPosition = resolvePosition(position, ctx);
@@ -211,6 +213,7 @@ class SheetService {
         order: order,
         energy: energy,
         darkYN: darkYN,
+        zOrder: zOrder,
       );
 
       currentMissionMap!
@@ -243,6 +246,23 @@ class SheetService {
   String _safeGet(List<String> cells, int index) {
     if (index < cells.length) return cells[index];
     return '';
+  }
+
+  // 위치값(G열) 앞에 붙은 Top_/Bottom_ 접두사로 z-order 힌트를 파싱한다.
+  ShapeZOrder _parseZOrderPrefix(String rawPosition) {
+    final lower = rawPosition.trimLeft().toLowerCase();
+    if (lower.startsWith('top_')) return ShapeZOrder.top;
+    if (lower.startsWith('bottom_')) return ShapeZOrder.bottom;
+    return ShapeZOrder.normal;
+  }
+
+  // Top_/Bottom_ 접두사를 제거한 순수 위치 문자열을 돌려준다.
+  String _stripZOrderPrefix(String rawPosition) {
+    final trimmed = rawPosition.trimLeft();
+    final lower = trimmed.toLowerCase();
+    if (lower.startsWith('top_')) return trimmed.substring(4);
+    if (lower.startsWith('bottom_')) return trimmed.substring(7);
+    return rawPosition;
   }
 
   String _firstParsableNumber(List<String> values) {
@@ -558,6 +578,7 @@ class EnemyData {
   final int? order;
   final int energy;
   final bool darkYN;
+  final ShapeZOrder zOrder;
 
   EnemyData({
     required this.command,
@@ -570,6 +591,7 @@ class EnemyData {
     this.attackSeconds,
     this.attackDamage,
     this.order,
+    this.zOrder = ShapeZOrder.normal,
   });
 
   @override

--- a/lib/src/routes/OneSecondGame.dart
+++ b/lib/src/routes/OneSecondGame.dart
@@ -875,6 +875,7 @@ class OneSecondGame extends FlameGame
       attackTime: enemy.attackSeconds,
       attackDamage: enemy.attackDamage,
       angle: rectAngle,
+      zOrder: enemy.zOrder,
     );
   }
 
@@ -889,6 +890,10 @@ class OneSecondGame extends FlameGame
 
     await add(shape);
     await shape.loaded;
+
+    // z-order 적용: 각 도형의 onLoad가 크기 기반 priority를 설정하므로,
+    // load 이후에 생성(시트) 순서 + Top_/Bottom_ 대역 기반 priority로 덮어쓴다.
+    shape.priority = _computeZPriority(enemy.zOrder);
 
     // behavior attach
     if (enemy.behavior != null) {
@@ -981,8 +986,24 @@ class OneSecondGame extends FlameGame
         throw Exception("Unknown shapeType");
     }
 
-    shape.priority = _globalSpawnCounter++;
     return shape;
+  }
+
+  // 생성(시트) 순서를 유지하면서 Top_/Bottom_ 대역으로 z-order를 분리한다.
+  // bottom < normal < top 순서로 항상 정렬되고, 같은 대역 안에서는 생성 순서대로 쌓인다.
+  static const int _zBandNormalBase = 1000000;
+  static const int _zBandTopBase = 2000000;
+
+  int _computeZPriority(ShapeZOrder zOrder) {
+    final seq = _globalSpawnCounter++;
+    switch (zOrder) {
+      case ShapeZOrder.bottom:
+        return seq;
+      case ShapeZOrder.normal:
+        return _zBandNormalBase + seq;
+      case ShapeZOrder.top:
+        return _zBandTopBase + seq;
+    }
   }
 
   // 1) 스케일 파싱 (Circle2 -> 2 -> 0.5배, Default=4 -> 1.0배)


### PR DESCRIPTION
## Summary
- Shape stacking order (z-order) is now driven by spawn/sheet order and is independent of shape size. Later-in-sheet shapes render on top.
- The Google Sheet position value (column G) accepts optional prefixes to override layering for any shape (both normal and trap shapes):
  - `Top_(x, y)` → shape is always drawn on top.
  - `Bottom_(x, y)` → shape is always drawn at the bottom.
  - No prefix → drawn in sheet order.
- Removed the size-based priority code (`priority = 100 + (1000 - size.x)`) from all five shape components; z-order is centralized at spawn time.

## Changes
- `config.dart`: added `enum ShapeZOrder { top, normal, bottom }`.
- `sheet_service.dart`: parse and strip `Top_`/`Bottom_` prefix from the position value; store `zOrder` on `EnemyData`.
- `PreparedEnemy.dart`: added `zOrder` field.
- `OneSecondGame.dart`: apply band-based priority (`bottom < normal < top`, spawn order within each band) after the shape loads; removed the old spawn-counter assignment.
- `CircleShape/RectangleShape/TriangleShape/PentagonShape/HexagonShape.dart`: removed size-based priority from `onLoad`.

## Test plan
- [ ] Shapes with no prefix stack in sheet order regardless of size (later = on top).
- [ ] `Top_` shape always renders above others; `Bottom_` shape always below.
- [ ] Prefixes work for both normal and trap (dark) shapes.
- [ ] Tap selection on overlapping shapes follows the new z-order.