### PR TITLE
feat: add how-to-play tutorial with per-session don't-show-again option

### DIFF
--- a/lib/src/routes/HowToPlayOverlay.dart
+++ b/lib/src/routes/HowToPlayOverlay.dart
@@ -1,0 +1,179 @@
+import 'package:figureout/src/config.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+class HowToPlayOverlay extends StatefulWidget {
+  /// Called when the user dismisses the overlay. [dontShowAgain] is true when
+  /// the "Don't show again" checkbox was ticked.
+  final ValueChanged<bool> onContinue;
+
+  const HowToPlayOverlay({super.key, required this.onContinue});
+
+  @override
+  State<HowToPlayOverlay> createState() => _HowToPlayOverlayState();
+}
+
+class _HowToPlayOverlayState extends State<HowToPlayOverlay> {
+  bool _dontShowAgain = false;
+
+  static const _items = [
+    ('assets/Circle_basic.svg', 'Tap to pop'),
+    ('assets/Triangle_basic.svg', 'Trap to pop'),
+    ('assets/Rectangle_basic.svg', 'Slice to pop'),
+    ('assets/Pentagon_basic.svg', 'Hold to pop'),
+    ('assets/Hexagon_basic.svg', 'Stretch to pop'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.of(context).size.width;
+    final iconSize = screenWidth * 0.11;
+    final fontSize = screenWidth * 0.048;
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => widget.onContinue(_dontShowAgain),
+      child: ColoredBox(
+        color: Colors.black.withValues(alpha: 0.65),
+        child: SafeArea(
+          child: Column(
+            children: [
+              const Spacer(flex: 2),
+              Padding(
+                padding: EdgeInsets.symmetric(horizontal: screenWidth * 0.12),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    for (final item in _items) ...[
+                      _HowToPlayRow(
+                        svgPath: item.$1,
+                        label: item.$2,
+                        iconSize: iconSize,
+                        fontSize: fontSize,
+                      ),
+                      SizedBox(height: screenWidth * 0.045),
+                    ],
+                  ],
+                ),
+              ),
+              const Spacer(flex: 2),
+              _DontShowAgainCheckbox(
+                checked: _dontShowAgain,
+                fontSize: fontSize,
+                spacing: screenWidth * 0.025,
+                onToggle: () =>
+                    setState(() => _dontShowAgain = !_dontShowAgain),
+              ),
+              SizedBox(height: screenWidth * 0.05),
+              Text(
+                'Click to continue',
+                style: TextStyle(
+                  fontFamily: appFontFamily,
+                  fontSize: fontSize * 0.95,
+                  fontWeight: FontWeight.w600,
+                  color: Colors.white,
+                  decoration: TextDecoration.none,
+                ),
+              ),
+              SizedBox(height: screenWidth * 0.12),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DontShowAgainCheckbox extends StatelessWidget {
+  final bool checked;
+  final double fontSize;
+  final double spacing;
+  final VoidCallback onToggle;
+
+  const _DontShowAgainCheckbox({
+    required this.checked,
+    required this.fontSize,
+    required this.spacing,
+    required this.onToggle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onToggle,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            checked ? Icons.check_box : Icons.check_box_outline_blank,
+            color: Colors.white,
+            size: fontSize * 1.2,
+          ),
+          SizedBox(width: spacing),
+          Text(
+            "Don't show again",
+            style: TextStyle(
+              fontFamily: appFontFamily,
+              fontSize: fontSize * 0.85,
+              fontWeight: FontWeight.w600,
+              color: Colors.white,
+              decoration: TextDecoration.none,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HowToPlayRow extends StatelessWidget {
+  final String svgPath;
+  final String label;
+  final double iconSize;
+  final double fontSize;
+
+  const _HowToPlayRow({
+    required this.svgPath,
+    required this.label,
+    required this.iconSize,
+    required this.fontSize,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(
+          width: iconSize,
+          height: iconSize,
+          child: SvgPicture.asset(svgPath, fit: BoxFit.contain),
+        ),
+        SizedBox(width: iconSize * 0.35),
+        Text(
+          '-',
+          style: TextStyle(
+            fontFamily: appFontFamily,
+            fontSize: fontSize,
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
+            decoration: TextDecoration.none,
+          ),
+        ),
+        SizedBox(width: iconSize * 0.35),
+        Expanded(
+          child: Text(
+            label,
+            style: TextStyle(
+              fontFamily: appFontFamily,
+              fontSize: fontSize,
+              fontWeight: FontWeight.w600,
+              color: Colors.white,
+              decoration: TextDecoration.none,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/routes/MainGameScreen.dart
+++ b/lib/src/routes/MainGameScreen.dart
@@ -1,6 +1,7 @@
 
 import 'package:figureout/src/routes/OneSecondGame.dart';
 import 'package:figureout/src/routes/AftermathScreen.dart';
+import 'package:figureout/src/routes/HowToPlayOverlay.dart';
 import 'package:figureout/src/routes/PausedScreen.dart';
 import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
@@ -81,6 +82,12 @@ class _MainGameScreenState extends State<MainGameScreen> {
             GameWidget(
               game: oneSec,
               overlayBuilderMap: {
+                'howto': (context, game) {
+                  final g = game as OneSecondGame;
+                  return HowToPlayOverlay(
+                    onContinue: g.handleHowToPlayContinue,
+                  );
+                },
                 'pause': (context, game) {
                   final g = game as OneSecondGame;
                   return PauseOverlayWidget(

--- a/lib/src/routes/OneSecondGame.dart
+++ b/lib/src/routes/OneSecondGame.dart
@@ -72,6 +72,11 @@ class OneSecondGame extends FlameGame
   int _currentAftermathStgIndex = 0;
   int _currentAftermathMsnIndex = 0;
 
+  // how-to-play intro (stage 1 mission 1)
+  Completer<void>? _howToPlayCompleter;
+  // "다시 보지 않기": 앱 실행(세션) 동안만 유지되는 플래그. 앱 재시작 시 초기화되어 다시 표시된다.
+  static bool _tutorialHiddenThisSession = false;
+
   StageResult? get currentAftermathResult => _currentAftermathResult;
   int get currentAftermathStars => _currentAftermathStars;
   int get currentAftermathStgIndex => _currentAftermathStgIndex;
@@ -572,6 +577,12 @@ class OneSecondGame extends FlameGame
 
     _stopEnemyBehaviors();
     _clearAllShapes();
+
+    // Stage 1 Mission 1: show how-to-play before the timer starts
+    final canProceed = await _awaitHowToPlayIfNeeded(stageIndex, missionIndex, runId);
+    if (!canProceed) {
+      return StageResult.cancelled;
+    }
 
     // 시간 데이터 분석
     double? missionSeconds = stage.missionTimeLimits[missionIndex];
@@ -1554,8 +1565,9 @@ class OneSecondGame extends FlameGame
       currentCircleRadius = null;
       blinkingMap.clear();
 
-      // 결과 화면도 제거
+      // 결과 / 튜토리얼 화면도 제거
       _removeAftermathOverlay();
+      _removeHowToPlayOverlay();
 
       children.whereType<BlinkingBehaviorComponent>()
           .forEach((b) => b.removeFromParent());
@@ -2480,6 +2492,7 @@ bool _isStraightLine(List<Vector2> path) {
 
   void pauseGame() {
     debugPrint("blinkingMap:${blinkingMap.values}");
+    if (overlays.isActive('howto')) return;
     if (overlays.isActive('pause')) return;
 
     if (!_missionResolved && remainingTime <= 0) {
@@ -2632,6 +2645,45 @@ bool _isStraightLine(List<Vector2> path) {
   
   void _removeAftermathOverlay() {
     if (overlays.isActive('aftermath')) overlays.remove('aftermath');
+  }
+
+  void _removeHowToPlayOverlay() {
+    if (overlays.isActive('howto')) overlays.remove('howto');
+    final completer = _howToPlayCompleter;
+    _howToPlayCompleter = null;
+    if (completer != null && !completer.isCompleted) {
+      completer.complete();
+    }
+  }
+
+  /// Stage 1 Mission 1 intro. Returns false if the run was cancelled while waiting.
+  Future<bool> _awaitHowToPlayIfNeeded(
+    int stageIndex,
+    int missionIndex,
+    int runId,
+  ) async {
+    if (stageIndex != 0 || missionIndex != 1 || _isContinuing) {
+      return true;
+    }
+
+    // 이번 세션에서 "다시 보지 않기"를 켰으면 건너뛴다. (앱 재시작 시엔 초기화되어 다시 표시)
+    if (_tutorialHiddenThisSession) {
+      return runId == _runToken;
+    }
+
+    _howToPlayCompleter = Completer<void>();
+    overlays.add('howto');
+    await _howToPlayCompleter!.future;
+    _howToPlayCompleter = null;
+
+    return runId == _runToken;
+  }
+
+  void handleHowToPlayContinue(bool dontShowAgain) {
+    if (dontShowAgain) {
+      _tutorialHiddenThisSession = true;
+    }
+    _removeHowToPlayOverlay();
   }
 
   void handleAftermathContinue() {


### PR DESCRIPTION
## Summary
- Add a how-to-play tutorial overlay shown at Stage 1 Mission 1
- Add a "Don't show again" checkbox that hides the tutorial for the current app session only
- The tutorial reappears after an app restart (per-session flag, not persisted)

## Details
- `HowToPlayOverlay.dart`: new stateful overlay with the "Don't show again" checkbox
- `OneSecondGame.dart`: `_awaitHowToPlayIfNeeded` gates the intro on Stage 1 Mission 1; `_tutorialHiddenThisSession` static flag controls per-session hiding and resets on restart
- `MainGameScreen.dart`: wires the `howto` overlay to `handleHowToPlayContinue`

## Test plan
- [ ] First launch: tutorial shows on Stage 1 Mission 1
- [ ] Check "Don't show again" then continue: tutorial no longer shows during the session
- [ ] Restart the app: tutorial shows again