### PR TITLE
feat: implement pentagon destruction animation

### DIFF
--- a/lib/src/components/HexagonShape.dart
+++ b/lib/src/components/HexagonShape.dart
@@ -7,6 +7,7 @@ import 'package:figureout/src/functions/blink_alpha_target.dart';
 import 'dart:math' as math;
 
 import '../effect/AttackExplosionEffect.dart';
+import '../effect/HexagonBurstEffect.dart';
 import '../functions/OverlapHighlightable.dart';
 import 'shape_path_utils.dart';
 
@@ -333,12 +334,11 @@ class HexagonShape extends PositionComponent
 
       if (_disappearT >= 1.0) {
 
-        // 일반 제거 explosion (zoom 제거)
+        // 일반 제거: 육각형 꼭짓점 방향으로 6갈래 파티클 버스트
         parent?.add(
-          AttackExplosionEffect(
-            basePath: _buildExplosionHexagonPath(),
+          HexagonBurstEffect(
             position: position.clone(),
-            size: size.clone(),
+            radius: (size.x / 2) * scale.x,
             color: const Color(0xFF398A63),
           ),
         );

--- a/lib/src/components/PentagonShape.dart
+++ b/lib/src/components/PentagonShape.dart
@@ -12,6 +12,7 @@ import 'package:flame/game.dart';
 import 'package:flutter/material.dart' hide Matrix4;
 
 import '../effect/AttackExplosionEffect.dart';
+import '../effect/PentagonBurstEffect.dart';
 import '../functions/OverlapHighlightable.dart';
 import 'shape_path_utils.dart';
 
@@ -64,19 +65,18 @@ class PentagonShape extends PositionComponent
   static const double _pressTick = 1.0;
   Vector2? _frozenPosition;
 
+  double _shakeElapsed = 0.0;
+  static const double _shakeFrequency = 45.0;
+  static const double _shakeAngleAmplitude = 0.07;
+
   // ===============================
-  // PULSE
+  // SHAKE ENVELOPE
   // ===============================
 
-  static const Color _pulseColor = Color(0xFFFF6AD5);
-
-  static const double _pulseMaxThickness = 18.0;
   static const double _pulseAppearTime = 0.10;
   static const double _pulseDisappearTime = 0.12;
-  static const double _pulseCycleSeconds = 0.36;
 
   double _pulseThicknessT = 0.0;
-  double _pulsePhase = 0.0;
 
   // ===============================
   // GEOMETRY
@@ -195,9 +195,11 @@ class PentagonShape extends PositionComponent
         _pulseThicknessT += dt / _pulseAppearTime;
       }
 
-      _pulsePhase += dt / _pulseCycleSeconds;
+      _shakeElapsed += dt;
 
-      _pulsePhase -= _pulsePhase.floorToDouble();
+      angle = sin(_shakeElapsed * _shakeFrequency) *
+          _shakeAngleAmplitude *
+          _pulseThicknessT;
 
       _pressElapsed += dt;
 
@@ -209,6 +211,7 @@ class PentagonShape extends PositionComponent
 
         if (energy <= 0) {
           wasRemovedByUser = true;
+          _playRemoveEffect();
           removeFromParent();
           return;
         }
@@ -227,6 +230,8 @@ class PentagonShape extends PositionComponent
       }
 
       _pressElapsed = 0.0;
+      _shakeElapsed = 0.0;
+      angle = 0.0;
     }
 
     if ((attackTime ?? 0) > 0) {
@@ -345,37 +350,6 @@ class PentagonShape extends PositionComponent
 
     super.render(canvas);
 
-    if (!isDark && _pulseThicknessT > 0.0) {
-
-      final totalThickness = _pulseMaxThickness * _pulseThicknessT;
-
-      final bandW = totalThickness / 2.5;
-
-      for (int i = 0; i < 3; i++) {
-
-        final innerR = _baseRadius + bandW * i;
-        final outerR = innerR + bandW;
-
-        final ring = _buildRingEvenOdd(_center, innerR, outerR);
-
-        final phase = (_pulsePhase + i / 3.0) % 1.0;
-
-        final tri = phase < 0.5 ? (phase * 2.0) : (2.0 - phase * 2.0);
-
-        final smooth = tri * tri * (3 - 2 * tri);
-
-        final opacity = lerpDouble(0.10, 0.34, smooth)!;
-
-        final paint = Paint()
-          ..style = PaintingStyle.fill
-          ..color = _pulseColor.withValues(
-            alpha: opacity * _pulseThicknessT * _blinkAlpha,
-          );
-
-        canvas.drawPath(ring, paint);
-      }
-    }
-
     if (_isLongPressing && !isDark && energy > 0) {
 
       final c = _visualPentagonCenter
@@ -433,23 +407,6 @@ class PentagonShape extends PositionComponent
     path.close();
 
     return path;
-  }
-
-  Path _buildRingEvenOdd(
-      Offset c,
-      double innerR,
-      double outerR,
-      ) {
-
-    final outer = _buildPentagonPath(c, outerR);
-    final inner = _buildPentagonPath(c, innerR);
-
-    final ring = Path()..fillType = PathFillType.evenOdd;
-
-    ring.addPath(outer, Offset.zero);
-    ring.addPath(inner, Offset.zero);
-
-    return ring;
   }
 
   Path _buildHandDrawnCircle(
@@ -543,12 +500,12 @@ class PentagonShape extends PositionComponent
     _isLongPressing = true;
 
     _pulseThicknessT = 0.0;
-    _pulsePhase = 0.0;
     _pressElapsed = 0.0;
 
     energy--;
     if (energy <= 0) {
       wasRemovedByUser = true;
+      _playRemoveEffect();
       removeFromParent();
       return;
     }
@@ -574,6 +531,16 @@ class PentagonShape extends PositionComponent
     }
 
     return null;
+  }
+
+  void _playRemoveEffect() {
+    parent?.add(
+      PentagonBurstEffect(
+        position: position.clone(),
+        radius: _baseRadius,
+        color: const Color(0xFFF3ACB1),
+      ),
+    );
   }
 
   Path _buildExplosionPentagonPath() {

--- a/lib/src/effect/HexagonBurstEffect.dart
+++ b/lib/src/effect/HexagonBurstEffect.dart
@@ -1,0 +1,127 @@
+import 'dart:math';
+import 'dart:ui';
+
+import 'package:flame/components.dart';
+import 'package:flutter/material.dart' show Curves;
+
+class HexagonBurstEffect extends PositionComponent {
+  final double radius;
+  final Color color;
+
+  static const int _segmentCount = 6;
+  // Aligns each fragment with a hexagon vertex direction (matches
+  // HexagonShape._buildHexagonPath's i * 60 degree layout, no offset).
+  static const double _angleOffset = 0.0;
+
+  static const double _totalDuration = 0.35;
+  static const double _growEnd = 0.55; // peak dash length reached here, then shrink
+
+  // How far the dash's slight hand-drawn bend swings off the straight axis,
+  // as a fraction of the dash's own half-length — small on purpose, this is
+  // a subtle wiggle, not the pronounced S-bend that read as a "wave".
+  static const double _curveAmpRatio = 0.15;
+
+  double _elapsed = 0.0;
+  bool isPaused = false;
+
+  HexagonBurstEffect({
+    required Vector2 position,
+    required this.radius,
+    required this.color,
+  }) : super(
+          position: position,
+          anchor: Anchor.center,
+        );
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    if (isPaused) return;
+    _elapsed += dt;
+    if (_elapsed >= _totalDuration) removeFromParent();
+  }
+
+  @override
+  void render(Canvas canvas) {
+    super.render(canvas);
+
+    final t = (_elapsed / _totalDuration).clamp(0.0, 1.0);
+
+    final pillHalfH = radius * 0.035;
+    final pillHalfLMax = radius * 0.24;
+
+    // Short, near-round "bean" at spawn and right before the pop — note the
+    // round stroke caps already add pillHalfH of visible length past each
+    // path endpoint, so this only needs to be a small fraction of pillHalfH
+    // to read as short (reference: short frame vs. the elongated max frame).
+    final startHalfLen = pillHalfH * 0.3;
+
+    // Shared growth curve: spread and length both start growing at t=0 and
+    // both reach their peak at the exact same moment (_growEnd), since they
+    // use this same clamped progress value — no independent timing for
+    // either one. Linear on purpose: an eased (easeOut) curve front-loads
+    // most of the growth into the first frame or two, which read as the
+    // fragments already being long/spread out right from the start.
+    final growP = (t / _growEnd).clamp(0.0, 1.0);
+
+    // Half-length: startHalfLen → pillHalfLMax (0~growEnd, via growP), then
+    // pillHalfLMax → startHalfLen (growEnd~100%, ease-in) — grows to a peak,
+    // then shrinks back down to a short blob before popping away.
+    final double pillHalfL;
+    if (t <= _growEnd) {
+      pillHalfL = lerpDouble(startHalfLen, pillHalfLMax, growP)!;
+    } else {
+      final p = Curves.easeIn.transform((t - _growEnd) / (1.0 - _growEnd));
+      pillHalfL = lerpDouble(pillHalfLMax, startHalfLen, p)!;
+    }
+
+    // Spread (distance from center): grows in lockstep with the length
+    // (same growP curve, so it starts and peaks at the same moments), then
+    // holds at its max — growP naturally stays at 1.0 past _growEnd — while
+    // only the length shrinks back down and opacity fades.
+    final spread = radius * lerpDouble(0.44, 1.07, growP)!;
+
+    // Opacity holds full almost the whole time, then fades hard right at
+    // the very end so the dashes visibly pop away (reference frame 8→9).
+    final double opacity;
+    if (t <= 0.8) {
+      opacity = 1.0;
+    } else {
+      opacity = 1.0 - Curves.easeIn.transform((t - 0.8) / 0.2);
+    }
+    if (opacity <= 0.01) return;
+
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = pillHalfH * 2
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round
+      ..color = color.withValues(alpha: opacity);
+
+    final dashPath = _buildDashPath(pillHalfL);
+
+    for (int i = 0; i < _segmentCount; i++) {
+      final angle = _angleOffset + (i / _segmentCount) * pi * 2;
+      canvas.save();
+      canvas.translate(cos(angle) * spread, sin(angle) * spread);
+      canvas.rotate(angle);
+      canvas.drawPath(dashPath, paint);
+      canvas.restore();
+    }
+  }
+
+  // A gently bent segment along the local X axis (the dash's long axis)
+  // from -halfLen to +halfLen — just a slight hand-drawn wiggle, not a
+  // pronounced S-curve — with strokeCap.round giving blunt (never pointy)
+  // ends regardless of length.
+  Path _buildDashPath(double halfLen) {
+    final amp = halfLen * _curveAmpRatio;
+    return Path()
+      ..moveTo(-halfLen, 0)
+      ..cubicTo(
+        -halfLen * 0.33, amp,
+        halfLen * 0.33, -amp,
+        halfLen, 0,
+      );
+  }
+}

--- a/lib/src/effect/PentagonBurstEffect.dart
+++ b/lib/src/effect/PentagonBurstEffect.dart
@@ -1,0 +1,119 @@
+import 'dart:math';
+import 'dart:ui';
+
+import 'package:flame/components.dart';
+import 'package:flutter/material.dart' show Curves;
+
+class PentagonBurstEffect extends PositionComponent {
+  final double radius;
+  final Color color;
+
+  static const int _segmentCount = 5;
+  // Aligns each fragment with a pentagon vertex direction (matches
+  // PentagonShape._buildPentagonPath's -90 + i*72 degree layout).
+  static const double _angleOffset = -pi / 2;
+
+  static const double _totalDuration = 0.55;
+  static const double _growEnd = 0.5; // peak dash length reached here, then shrink
+
+  // How far the S-bend's control points swing off the straight axis,
+  // as a fraction of the dash's own half-length.
+  static const double _curveAmpRatio = 0.42;
+
+  double _elapsed = 0.0;
+  bool isPaused = false;
+
+  PentagonBurstEffect({
+    required Vector2 position,
+    required this.radius,
+    required this.color,
+  }) : super(
+          position: position,
+          anchor: Anchor.center,
+        );
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    if (isPaused) return;
+    _elapsed += dt;
+    if (_elapsed >= _totalDuration) removeFromParent();
+  }
+
+  @override
+  void render(Canvas canvas) {
+    super.render(canvas);
+
+    final t = (_elapsed / _totalDuration).clamp(0.0, 1.0);
+
+    final pillHalfH = radius * 0.065;
+    final pillHalfLMax = radius * 0.16;
+
+    // Short, near-round "bean" at spawn and right before the pop — note the
+    // round stroke caps already add pillHalfH of visible length past each
+    // path endpoint, so this only needs to be a small fraction of pillHalfH
+    // to read as short (reference: short frame vs. the elongated max frame).
+    final startHalfLen = pillHalfH * 0.3;
+
+    // Half-length: startHalfLen → pillHalfLMax (0~growEnd, ease-out), then
+    // pillHalfLMax → startHalfLen (growEnd~100%, ease-in) — grows to a peak,
+    // then shrinks back down to a short blob before popping away.
+    final double pillHalfL;
+    if (t <= _growEnd) {
+      final p = Curves.easeOut.transform(t / _growEnd);
+      pillHalfL = lerpDouble(startHalfLen, pillHalfLMax, p)!;
+    } else {
+      final p = Curves.easeIn.transform((t - _growEnd) / (1.0 - _growEnd));
+      pillHalfL = lerpDouble(pillHalfLMax, startHalfLen, p)!;
+    }
+
+    // Spread (distance from center) grows monotonically and visibly for the
+    // whole effect, never retreating even while the dash shrinks back down —
+    // dashes start a bit apart and keep drifting further out as they animate.
+    final spreadP = Curves.easeOut.transform(t);
+    final spread = radius * lerpDouble(0.46, 0.95, spreadP)!;
+
+    // Opacity holds full almost the whole time, then fades hard right at
+    // the very end so the dashes visibly pop away (reference frame 4→5).
+    final double opacity;
+    if (t <= 0.82) {
+      opacity = 1.0;
+    } else {
+      opacity = 1.0 - Curves.easeIn.transform((t - 0.82) / 0.18);
+    }
+    if (opacity <= 0.01) return;
+
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = pillHalfH * 2
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round
+      ..color = color.withValues(alpha: opacity);
+
+    final dashPath = _buildDashPath(pillHalfL);
+
+    for (int i = 0; i < _segmentCount; i++) {
+      final angle = _angleOffset + (i / _segmentCount) * pi * 2;
+      canvas.save();
+      canvas.translate(cos(angle) * spread, sin(angle) * spread);
+      canvas.rotate(angle);
+      canvas.drawPath(dashPath, paint);
+      canvas.restore();
+    }
+  }
+
+  // A single cubic-bezier S-bend along the local X axis (the dash's long
+  // axis) from -halfLen to +halfLen, so the curve is visible across the
+  // whole dash rather than only in one small kink, with strokeCap.round
+  // giving blunt (never pointy) ends regardless of length.
+  Path _buildDashPath(double halfLen) {
+    final amp = halfLen * _curveAmpRatio;
+    return Path()
+      ..moveTo(-halfLen, 0)
+      ..cubicTo(
+        -halfLen * 0.33, amp,
+        halfLen * 0.33, -amp,
+        halfLen, 0,
+      );
+  }
+}


### PR DESCRIPTION
-Add pentagon vibration effect on long press
- Add five particle burst effect on long press trigger
- Particles spread in five directions aligned to pentagon vertices
- Particles start as small blobs, grow to max length, shrink and fade out