### PR TITLE
fix: parametric value out-of-range error on circle destruction

### DIFF
--- a/lib/src/effect/CircleDisappearEffect.dart
+++ b/lib/src/effect/CircleDisappearEffect.dart
@@ -60,10 +60,12 @@ class CircleDisappearEffect extends PositionComponent {
     // then shrinks back down to a short blob before popping away.
     final double pillHalfL;
     if (t <= _growEnd) {
-      final p = Curves.easeOut.transform(t / _growEnd);
+      final p = Curves.easeOut.transform((t / _growEnd).clamp(0.0, 1.0));
       pillHalfL = lerpDouble(startHalfLen, pillHalfLMax, p)!;
     } else {
-      final p = Curves.easeIn.transform((t - _growEnd) / (1.0 - _growEnd));
+      final p = Curves.easeIn.transform(
+        ((t - _growEnd) / (1.0 - _growEnd)).clamp(0.0, 1.0),
+      );
       pillHalfL = lerpDouble(pillHalfLMax, startHalfLen, p)!;
     }
 
@@ -80,7 +82,11 @@ class CircleDisappearEffect extends PositionComponent {
     if (t <= 0.82) {
       opacity = 1.0;
     } else {
-      opacity = 1.0 - Curves.easeIn.transform((t - 0.82) / 0.18);
+      // t is clamped to [0,1] above, but (t - 0.82) / 0.18 can still land a
+      // hair past 1.0 from floating-point rounding (e.g. 1.0000000000000002),
+      // and Curve.transform asserts its input is exactly within [0, 1].
+      final fadeT = ((t - 0.82) / 0.18).clamp(0.0, 1.0);
+      opacity = 1.0 - Curves.easeIn.transform(fadeT);
     }
     if (opacity <= 0.01) return;
 

--- a/lib/src/effect/EncircleSliceEffect.dart
+++ b/lib/src/effect/EncircleSliceEffect.dart
@@ -59,7 +59,7 @@ class EncircleSliceEffect extends PositionComponent {
 
     if (t <= _t1) {
       // Phase 1: basePath rotates 90° (ease-out) + minimal scale reduction
-      final localT = t / _t1;
+      final localT = (t / _t1).clamp(0.0, 1.0);
       final progress = Curves.easeOut.transform(localT);
       final angle = _initialAngle + (pi / 2) * progress;
       final sc = lerpDouble(1.0, 0.85, progress)!;
@@ -77,7 +77,7 @@ class EncircleSliceEffect extends PositionComponent {
       // visible gaps between them; length AND spread grow together to a peak;
       // past the peak, only the length shrinks back to its starting size
       // (spread keeps drifting outward, never retreats) and only then fades.
-      final localT = (t - _t1) / (1.0 - _t1);
+      final localT = ((t - _t1) / (1.0 - _t1)).clamp(0.0, 1.0);
 
       const double growEnd = 0.55; // growth phase ends here, then shrink begins
 
@@ -98,10 +98,12 @@ class EncircleSliceEffect extends PositionComponent {
       // corner radius shrinks along with it instead of flooring the min size.
       final double lengthFactor;
       if (localT <= growEnd) {
-        final p = Curves.easeOut.transform(localT / growEnd);
+        final p = Curves.easeOut.transform((localT / growEnd).clamp(0.0, 1.0));
         lengthFactor = lerpDouble(startLen, 1.0, p)!;
       } else {
-        final p = Curves.easeIn.transform((localT - growEnd) / (1.0 - growEnd));
+        final p = Curves.easeIn.transform(
+          ((localT - growEnd) / (1.0 - growEnd)).clamp(0.0, 1.0),
+        );
         lengthFactor = lerpDouble(1.0, startLen, p)!;
       }
       final pillHalfW = pillHalfWMax * lengthFactor;
@@ -119,7 +121,8 @@ class EncircleSliceEffect extends PositionComponent {
       if (localT <= 0.8) {
         opacity = 1.0;
       } else {
-        opacity = 1.0 - Curves.easeIn.transform((localT - 0.8) / 0.2);
+        final fadeT = ((localT - 0.8) / 0.2).clamp(0.0, 1.0);
+        opacity = 1.0 - Curves.easeIn.transform(fadeT);
       }
 
       // ignore: deprecated_member_use

--- a/lib/src/effect/HexagonBurstEffect.dart
+++ b/lib/src/effect/HexagonBurstEffect.dart
@@ -71,7 +71,9 @@ class HexagonBurstEffect extends PositionComponent {
     if (t <= _growEnd) {
       pillHalfL = lerpDouble(startHalfLen, pillHalfLMax, growP)!;
     } else {
-      final p = Curves.easeIn.transform((t - _growEnd) / (1.0 - _growEnd));
+      final p = Curves.easeIn.transform(
+        ((t - _growEnd) / (1.0 - _growEnd)).clamp(0.0, 1.0),
+      );
       pillHalfL = lerpDouble(pillHalfLMax, startHalfLen, p)!;
     }
 
@@ -87,7 +89,8 @@ class HexagonBurstEffect extends PositionComponent {
     if (t <= 0.8) {
       opacity = 1.0;
     } else {
-      opacity = 1.0 - Curves.easeIn.transform((t - 0.8) / 0.2);
+      final fadeT = ((t - 0.8) / 0.2).clamp(0.0, 1.0);
+      opacity = 1.0 - Curves.easeIn.transform(fadeT);
     }
     if (opacity <= 0.01) return;
 

--- a/lib/src/effect/PentagonBurstEffect.dart
+++ b/lib/src/effect/PentagonBurstEffect.dart
@@ -60,10 +60,12 @@ class PentagonBurstEffect extends PositionComponent {
     // then shrinks back down to a short blob before popping away.
     final double pillHalfL;
     if (t <= _growEnd) {
-      final p = Curves.easeOut.transform(t / _growEnd);
+      final p = Curves.easeOut.transform((t / _growEnd).clamp(0.0, 1.0));
       pillHalfL = lerpDouble(startHalfLen, pillHalfLMax, p)!;
     } else {
-      final p = Curves.easeIn.transform((t - _growEnd) / (1.0 - _growEnd));
+      final p = Curves.easeIn.transform(
+        ((t - _growEnd) / (1.0 - _growEnd)).clamp(0.0, 1.0),
+      );
       pillHalfL = lerpDouble(pillHalfLMax, startHalfLen, p)!;
     }
 
@@ -79,7 +81,8 @@ class PentagonBurstEffect extends PositionComponent {
     if (t <= 0.82) {
       opacity = 1.0;
     } else {
-      opacity = 1.0 - Curves.easeIn.transform((t - 0.82) / 0.18);
+      final fadeT = ((t - 0.82) / 0.18).clamp(0.0, 1.0);
+      opacity = 1.0 - Curves.easeIn.transform(fadeT);
     }
     if (opacity <= 0.01) return;
 


### PR DESCRIPTION
- Fix floating-point precision causing parametric value to exceed 1.0 (e.g. 1.0000000000000002)
- Clamp value to [0, 1] range before use