### PR TITLE
fix: clear leftover destruction effects when retrying mission

### DIFF
--- a/lib/src/components/CircleShape.dart
+++ b/lib/src/components/CircleShape.dart
@@ -118,9 +118,9 @@ class CircleShape extends PositionComponent
 
     if (isPaused) return;
 
-    if (isDark) {
+    if (isDark && attackTime != null) {
       _darkLifespan += dt;
-      if (_darkLifespan >= (attackTime ?? 3.0)) {
+      if (_darkLifespan >= attackTime!) {
         removeFromParent();
         return;
       }

--- a/lib/src/components/RectangleShape.dart
+++ b/lib/src/components/RectangleShape.dart
@@ -174,13 +174,15 @@ class RectangleShape extends PositionComponent
 
     if (isPaused) return;
 
-    if (isDark) {
+    if (isDark && attackTime != null) {
       _darkLifespan += dt;
-      if (_darkLifespan >= (attackTime ?? 3.0)) {
+      if (_darkLifespan >= attackTime!) {
         removeFromParent();
         return;
       }
     }
+
+    if ((attackTime ?? 0) <= 0 || !isAttackable) return;
 
     _attackElapsed += dt;
 

--- a/lib/src/routes/OneSecondGame.dart
+++ b/lib/src/routes/OneSecondGame.dart
@@ -522,7 +522,10 @@ class OneSecondGame extends FlameGame
           c is PentagonShape ||
           c is TriangleShape ||
           c is HexagonShape ||
-          c is Effect) {
+          c is Effect ||
+          c is AttackExplosionEffect ||
+          c is EncircleSliceEffect ||
+          c is CircleDisappearEffect) {
         c.removeFromParent();
       }
     }
@@ -2800,7 +2803,10 @@ bool _isStraightLine(List<Vector2> path) {
     _resumeFromFailure();
   }
 
-  void handleAftermathRetry() => onRefresh();
+  void handleAftermathRetry() {
+    _removeAftermathOverlay();
+    runStageWithAftermath(_selectedStageIndex, _selectedMissionIndex);
+  }
 
   void handleAftermathPlay() {
     _removeAftermathOverlay();
@@ -2848,7 +2854,7 @@ bool _isStraightLine(List<Vector2> path) {
 
   void handlePauseRetry() {
     resumeGame();
-    onRefresh();
+    runStageWithAftermath(_selectedStageIndex, _selectedMissionIndex);
   }
 
   void handlePauseMenu() {


### PR DESCRIPTION
- Reset/dispose destruction effect particles and animations between mission sessions
- Prevent previous mission's explosion effects from carrying over into the new mission's background