### PR TITLE
feat: add rewarded ad to refill heart when out of hearts

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,7 @@ import 'package:figureout/src/routes/StageSelect.dart';
 import 'package:figureout/src/routes/EndlessGameScreen.dart';
 import 'package:figureout/src/routes/route_args.dart';
 import 'package:figureout/src/services/audio_manager.dart';
+import 'package:figureout/src/services/ad_manager.dart';
 
 final GlobalKey<NavigatorState> rootNavigatorKey = GlobalKey<NavigatorState>();
 final RouteObserver<ModalRoute<void>> routeObserver = RouteObserver<ModalRoute<void>>();
@@ -139,6 +140,8 @@ void main() async {
 
   await AudioManager.instance.init();
   await AudioManager.instance.setBgmTrack(5);
+
+  await AdManager.instance.init();
 
   runApp(figureoutMain());
 }

--- a/lib/src/routes/MissionSelect.dart
+++ b/lib/src/routes/MissionSelect.dart
@@ -6,6 +6,8 @@ import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../config.dart';
+import '../services/ad_manager.dart';
+import '../services/heart_service.dart';
 import 'menuAppBar.dart';
 import 'route_args.dart';
 import 'NoHeartsOverlay.dart';
@@ -240,7 +242,25 @@ class _MissionSelectScreenState extends State<MissionSelectScreen> {
                                     color: Colors.transparent,
                                     child: NoHeartsOverlay(
                                       onClose: () => Navigator.of(ctx).pop(),
-                                      onWatchAd: () => Navigator.of(ctx).pop(),
+                                      onWatchAd: () {
+                                        bool rewardEarned = false;
+                                        AdManager.instance.showRewardedAd(
+                                          onUserEarnedReward: () {
+                                            rewardEarned = true;
+                                          },
+                                          onAdClosed: () async {
+                                            // 보상을 받은 경우에만 하트를 충전한다.
+                                            if (rewardEarned) {
+                                              await HeartService.addHeart();
+                                            }
+                                            if (ctx.mounted) Navigator.of(ctx).pop();
+                                          },
+                                          onAdUnavailable: () {
+                                            // 아직 광고가 로드되지 않음: 다이얼로그는 유지하고
+                                            // 다음 로드는 AdManager 내부에서 자동으로 재시도된다.
+                                          },
+                                        );
+                                      },
                                     ),
                                   ),
                                 );

--- a/lib/src/services/ad_manager.dart
+++ b/lib/src/services/ad_manager.dart
@@ -1,0 +1,95 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
+
+/// 리워드(보상형) 광고의 로드/노출을 담당하는 싱글턴.
+/// 현재는 "하트 소진 시 광고 시청 -> 하트 1개 충전" 용도로만 사용한다.
+class AdManager {
+  static final AdManager _instance = AdManager._internal();
+  static AdManager get instance => _instance;
+
+  AdManager._internal();
+
+  // TODO(release): 정식 배포 전 AdMob 콘솔에서 발급받은 실제 리워드 광고 단위 ID로 교체할 것.
+  // 아래는 Google이 제공하는 테스트 전용 ID로, 실제 수익은 발생하지 않는다.
+  // https://developers.google.com/admob/flutter/test-ads
+  String get _rewardedAdUnitId {
+    if (Platform.isIOS) return 'ca-app-pub-3940256099942544/1712485313';
+    return 'ca-app-pub-3940256099942544/5224354917'; // Android
+  }
+
+  RewardedAd? _rewardedAd;
+  bool _isLoading = false;
+
+  bool get isAdReady => _rewardedAd != null;
+
+  /// Mobile Ads SDK 초기화 + 첫 리워드 광고 미리 로드.
+  Future<void> init() async {
+    if (kIsWeb) return;
+    await MobileAds.instance.initialize();
+    loadRewardedAd();
+  }
+
+  /// 다음에 보여줄 리워드 광고를 미리 로드해둔다.
+  void loadRewardedAd() {
+    if (kIsWeb || _isLoading || _rewardedAd != null) return;
+    _isLoading = true;
+
+    RewardedAd.load(
+      adUnitId: _rewardedAdUnitId,
+      request: const AdRequest(),
+      rewardedAdLoadCallback: RewardedAdLoadCallback(
+        onAdLoaded: (ad) {
+          _rewardedAd = ad;
+          _isLoading = false;
+        },
+        onAdFailedToLoad: (error) {
+          _rewardedAd = null;
+          _isLoading = false;
+          debugPrint('[AdManager] Rewarded ad failed to load: $error');
+        },
+      ),
+    );
+  }
+
+  /// 리워드 광고를 노출한다.
+  /// - [onUserEarnedReward]: 시청 완료(보상 획득) 시 호출.
+  /// - [onAdClosed]: 광고가 닫혔을 때(보상 획득 여부와 무관하게) 호출.
+  /// - [onAdUnavailable]: 아직 광고가 로드되지 않아 보여줄 수 없을 때 호출.
+  void showRewardedAd({
+    required VoidCallback onUserEarnedReward,
+    VoidCallback? onAdClosed,
+    VoidCallback? onAdUnavailable,
+  }) {
+    final ad = _rewardedAd;
+    if (kIsWeb || ad == null) {
+      onAdUnavailable?.call();
+      loadRewardedAd();
+      return;
+    }
+
+    // 재사용 방지: 보여줄 광고를 즉시 비우고 다음 광고를 새로 로드한다.
+    _rewardedAd = null;
+
+    ad.fullScreenContentCallback = FullScreenContentCallback(
+      onAdDismissedFullScreenContent: (ad) {
+        ad.dispose();
+        onAdClosed?.call();
+        loadRewardedAd();
+      },
+      onAdFailedToShowFullScreenContent: (ad, error) {
+        ad.dispose();
+        debugPrint('[AdManager] Rewarded ad failed to show: $error');
+        onAdUnavailable?.call();
+        loadRewardedAd();
+      },
+    );
+
+    ad.show(
+      onUserEarnedReward: (ad, reward) {
+        onUserEarnedReward();
+      },
+    );
+  }
+}

--- a/lib/src/services/heart_service.dart
+++ b/lib/src/services/heart_service.dart
@@ -1,0 +1,25 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../config.dart';
+
+/// 하트 개수/재충전 타이머를 다루는 공용 헬퍼.
+class HeartService {
+  /// 광고 시청 보상 등으로 하트를 즉시 지급한다. (기본 1개)
+  static Future<void> addHeart({int amount = 1}) async {
+    final prefs = await SharedPreferences.getInstance();
+    int hearts = (prefs.getInt('hearts') ?? maxHearts).clamp(0, maxHearts);
+    hearts = (hearts + amount).clamp(0, maxHearts);
+    await prefs.setInt('hearts', hearts);
+
+    if (hearts >= maxHearts) {
+      // 가득 찼으면 재충전 타이머를 멈춘다.
+      await prefs.remove('next_heart_time');
+    } else if (prefs.getInt('next_heart_time') == null) {
+      // 타이머가 없는 상태였다면(예: 하트가 0개라 타이머 시작 전) 새로 시작한다.
+      await prefs.setInt(
+        'next_heart_time',
+        DateTime.now().millisecondsSinceEpoch + heartRefillIntervalSec * 1000,
+      );
+    }
+  }
+}


### PR DESCRIPTION
- Show "watch ad" button when hearts are depleted
- Load and display AdMob rewarded ad on button tap
- Grant one heart on ad watch completion